### PR TITLE
GURU-104: Build profile readiness scoring docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Run the local Streamlit prototype to explore:
 - auto-scheduled prep sessions
 - mock interview tracking
 - profile readiness scoring
+  - Inputs: resume ATS compliance, formatting, impact, LinkedIn profile feedback, and optional mentor/recruiter review notes
+  - Output: profile readiness score summarizing resume & LinkedIn profile strength before prep
+  - Output: tracked readiness changes highlighting priority gaps for users to address
 - salary negotiation support prompts
 
 Command:
 `streamlit run gurukul_quick_app.py`
-
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Optional 1:1 review with mentor/recruiter
 
 Score and track profile readiness
 
+Supporting spec: [Profile readiness documentation pack](docs/profile-readiness/README.md) for first-prototype scoring, signals, and acceptance criteria
+
 🛣️ 1. Personalized Roadmap Creation
 User defines target role (e.g., SDE, PM) and time frame (e.g., 30 days)
 
@@ -70,4 +72,3 @@ Run the local Streamlit prototype to explore:
 
 Command:
 `streamlit run gurukul_quick_app.py`
-

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Match internal mentor availability for booked 1:1 sessions
 
 Dynamic adjustments for missed or rescheduled tasks
 
+Missed solo tasks move to the next open prep slot within the user's availability, shifting later unscheduled work only when needed
+
+Missed or rescheduled mentor sessions keep mentor availability as the scheduling constraint: release the missed booking, show matching internal mentor availability, and require user confirmation before booking a new 1:1 session
+
 🧪 4. Mock Exams & Interviews
 DSA/technical mock tests with scoring, timing, and analytics
 

--- a/docs/profile-readiness/README.md
+++ b/docs/profile-readiness/README.md
@@ -1,0 +1,34 @@
+# Profile Readiness Documentation
+
+This documentation pack supports the Profile & Application Readiness area of Gurukul's product scope. The root [README](../../README.md) remains the source of truth for the overall product; these docs define the first-prototype behavior for calculating, explaining, and tracking profile readiness before prep begins.
+
+## User Problem
+
+Candidates often enter interview prep with uneven resume quality, incomplete LinkedIn information, unclear evidence of impact, or no recruiter/mentor review. Gurukul should help users understand how ready their profile is, which gaps matter most, and what actions can improve their readiness score before they spend time on roadmap tasks, mock exams, or salary negotiation support.
+
+## First Prototype Scope
+
+The first prototype should:
+
+- calculate a profile readiness score from resume ATS compliance, formatting, impact, LinkedIn profile feedback, and optional mentor/recruiter review notes;
+- show the score as a readiness band with a short explanation of the strongest and weakest categories;
+- track score changes after profile imports, manual edits, feedback updates, or mentor/recruiter review notes;
+- recommend the next best profile actions based on the largest weighted readiness gaps;
+- preserve enough scoring context to explain why the score changed.
+
+## Out Of Scope
+
+The first prototype should not:
+
+- guarantee job application outcomes or interview callbacks;
+- replace human mentor/recruiter judgment;
+- automatically submit resumes, LinkedIn updates, or job applications;
+- scrape private LinkedIn data without explicit user action;
+- compare users against named peers or expose another user's profile signals;
+- calculate interview readiness scoring, which remains part of Mock Exams & Interviews.
+
+## Supporting Docs
+
+- [Scoring model](scoring-model.md) defines categories, inputs, weights, readiness bands, and edge cases.
+- [Signals and events](signals-and-events.md) defines the tracking events needed for imports, recalculation, and recommendation interactions.
+- [Acceptance criteria](acceptance-criteria.md) defines user-facing scenarios for prototype acceptance.

--- a/docs/profile-readiness/acceptance-criteria.md
+++ b/docs/profile-readiness/acceptance-criteria.md
@@ -1,0 +1,53 @@
+# Profile Readiness Acceptance Criteria
+
+These scenarios define expected user-facing behavior for the first profile readiness scoring prototype. They support the root [README](../../README.md) and do not replace its product scope.
+
+## Scenarios
+
+### 1. Resume Import Creates An Initial Score
+
+Given a user uploads a parseable resume, when analysis completes, then Gurukul shows a profile readiness score, readiness band, category breakdown, and at least one recommended next action.
+
+### 2. Missing Resume Shows An Empty State
+
+Given a user has not uploaded or imported a resume, when they open profile readiness, then Gurukul does not show a numeric score and prompts the user to upload or import a resume.
+
+### 3. Unparseable Resume Explains The Blocker
+
+Given a user uploads a resume that cannot be parsed, when analysis completes, then Gurukul explains that the file could not be read reliably, caps ATS compliance, withholds impact scoring, and recommends uploading a parseable file.
+
+### 4. Missing LinkedIn Feedback Shows A Provisional Score
+
+Given a user has a scored resume but no LinkedIn feedback, when they view readiness, then Gurukul shows a provisional score, identifies LinkedIn profile feedback as missing, and prompts the user to add or skip LinkedIn information.
+
+### 5. Manual Profile Updates Can Change The Score
+
+Given a user edits resume or LinkedIn feedback inputs, when readiness is recalculated, then Gurukul shows the new score, score delta, updated band when applicable, and the category that changed most.
+
+### 6. Mentor Or Recruiter Review Adds Human Context
+
+Given a mentor or recruiter adds review notes, when readiness is recalculated, then Gurukul includes the mentor/recruiter review category, marks the score as human-reviewed, and updates recommendations based on priority gaps from the review.
+
+### 7. Recommendations Prioritize The Largest Gap
+
+Given multiple categories have issues, when recommendations are generated, then Gurukul ranks the largest weighted readiness gap first and explains why that action is expected to improve readiness.
+
+### 8. Completed Recommendations Trigger Recalculation
+
+Given a user completes a recommended profile action, when completion is saved, then Gurukul requests a readiness recalculation and shows whether the score changed after the update.
+
+### 9. Target Role Changes Reframe Role Alignment
+
+Given a user changes their target role, when readiness is recalculated, then Gurukul updates role relevance inputs, preserves score history, and explains that the score changed because the target role changed.
+
+### 10. Duplicate Imports Do Not Create False Progress
+
+Given a user imports the same resume or LinkedIn feedback without changes, when analysis runs, then Gurukul identifies it as a duplicate import, keeps the existing score, and does not show a score increase.
+
+### 11. Privacy-Sensitive Content Is Not Exposed In Events
+
+Given profile readiness tracking events are emitted, when event payloads are inspected, then they contain identifiers and scoring metadata but no raw resume text, raw LinkedIn profile text, mentor/recruiter notes, contact information, or external profile URLs.
+
+### 12. Score History Explains Changes Over Time
+
+Given a user has multiple readiness recalculations, when they view score history, then Gurukul shows each score, band, score delta, trigger reason, and changed category without exposing private profile content.

--- a/docs/profile-readiness/scoring-model.md
+++ b/docs/profile-readiness/scoring-model.md
@@ -1,0 +1,66 @@
+# Profile Readiness Scoring Model
+
+This model defines how the first prototype calculates the profile readiness score named in the root [README](../../README.md). The score summarizes resume and LinkedIn profile strength before prep and highlights priority gaps for users to address.
+
+## Score Categories
+
+| Category | Weight | Purpose |
+| --- | ---: | --- |
+| Resume ATS compliance | 30% | Measures whether the resume can be parsed and screened by applicant tracking systems. |
+| Resume formatting | 15% | Measures readability, structure, section clarity, length, and consistency. |
+| Resume impact | 25% | Measures outcome-oriented bullets, quantified achievements, role relevance, and clarity of scope. |
+| LinkedIn profile feedback | 20% | Measures completeness and alignment between LinkedIn profile, target role, and resume narrative. |
+| Mentor/recruiter review | 10% | Incorporates optional qualitative feedback from a mentor or recruiter. |
+
+Weights must sum to 100%. Category scores use a 0 to 100 scale before weighting.
+
+## Inputs
+
+The scoring model accepts these inputs:
+
+- uploaded resume text and parser metadata;
+- ATS compliance findings, including parse success, contact information presence, section detection, keyword alignment, and unsupported formatting flags;
+- formatting findings, including section order, bullet consistency, page length, tense consistency, and readability issues;
+- impact findings, including quantified outcomes, action verbs, role relevance, seniority signals, and repeated vague claims;
+- LinkedIn profile feedback entered or imported by the user, including headline, About section, experience completeness, skills, projects, and consistency with the resume;
+- optional mentor/recruiter review notes, including a rating, priority gaps, and confidence level when provided.
+
+If a target role is available from roadmap creation, role relevance should use that target role. If no target role is available, the category should use general interview-prep quality checks and clearly mark role-specific guidance as limited.
+
+## Weighted Calculation
+
+Calculate the overall readiness score with this formula:
+
+```text
+overall_score =
+  (ats_score * 0.30) +
+  (formatting_score * 0.15) +
+  (impact_score * 0.25) +
+  (linkedin_score * 0.20) +
+  (mentor_review_score * 0.10)
+```
+
+Round the final score to the nearest whole number. Store the unrounded value for change tracking so small improvements are not lost across recalculations.
+
+## Readiness Bands
+
+| Band | Score Range | User Meaning |
+| --- | ---: | --- |
+| Not ready | 0-39 | Major profile gaps block effective application prep. |
+| Needs work | 40-64 | Core profile exists, but important gaps remain. |
+| Approaching ready | 65-79 | Profile is usable, with focused improvements recommended. |
+| Ready | 80-89 | Profile is strong enough to support active prep and applications. |
+| Strong | 90-100 | Profile is polished, consistent, and role-aligned. |
+
+The interface should display both the numeric score and the readiness band. Recommendations should prioritize the largest weighted readiness gap, calculated as `(100 - category_score) * category_weight`, then the highest-impact unresolved issue within that category.
+
+## Edge Cases
+
+- No resume uploaded: return no overall score, show an empty state, and prompt the user to import or upload a resume.
+- Resume cannot be parsed: cap ATS compliance at 20, withhold impact scoring until readable text is available, and recommend uploading a parseable file.
+- Missing LinkedIn data: set LinkedIn profile feedback to 0 only after the user skips or confirms they do not want to provide it; otherwise mark it incomplete and show a provisional score.
+- No mentor/recruiter review: use a neutral default of 50 for the mentor/recruiter review category and label the score as not yet human-reviewed.
+- Conflicting mentor/recruiter review notes: use the most recent review as the active score input and preserve prior reviews in score history.
+- Target role changes: recalculate role relevance inputs and create a score history entry explaining that the target role changed.
+- Duplicate imports: ignore exact duplicate resume or LinkedIn imports and do not create a new score-change event.
+- Low confidence findings: include the score, but show that recommendations are based on limited evidence.

--- a/docs/profile-readiness/signals-and-events.md
+++ b/docs/profile-readiness/signals-and-events.md
@@ -1,0 +1,167 @@
+# Profile Readiness Signals And Events
+
+This document defines the first-prototype tracking events for profile completion, readiness recalculation, and recommendation interactions. Events should help explain score changes and support product analytics without storing unnecessary private profile content.
+
+## Event Principles
+
+- Track actions and scoring metadata, not raw resume text or private LinkedIn content.
+- Use stable user, profile, and score identifiers supplied by the application layer.
+- Include source and confidence fields when a score or recommendation depends on inferred data.
+- Emit events after the user completes an action or the system completes a recalculation.
+
+## Shared Properties
+
+Each event should include:
+
+| Property | Description |
+| --- | --- |
+| `event_id` | Unique identifier for the event. |
+| `user_id` | Internal user identifier. |
+| `profile_id` | Internal profile readiness record identifier. |
+| `occurred_at` | Timestamp when the event occurred. |
+| `source` | Action source, such as `resume_upload`, `linkedin_import`, `manual_edit`, `mentor_review`, or `system_recalculation`. |
+| `schema_version` | Event schema version, starting with `1`. |
+
+## Profile Completion Events
+
+### `profile_readiness_resume_imported`
+
+Emitted when a user uploads or imports a resume for readiness scoring.
+
+Properties:
+
+- `resume_document_id`
+- `file_type`
+- `parse_status`
+- `detected_sections_count`
+- `duplicate_import`
+
+### `profile_readiness_linkedin_feedback_added`
+
+Emitted when LinkedIn profile feedback is entered, imported, or updated.
+
+Properties:
+
+- `feedback_source`
+- `completion_fields_present`
+- `role_alignment_available`
+- `manual_edit`
+
+### `profile_readiness_mentor_review_added`
+
+Emitted when mentor/recruiter review notes are added or updated.
+
+Properties:
+
+- `review_id`
+- `reviewer_type`
+- `review_score`
+- `priority_gap_count`
+- `review_confidence`
+
+### `profile_readiness_completion_changed`
+
+Emitted when required or optional profile readiness inputs move between incomplete, provisional, and complete states.
+
+Properties:
+
+- `previous_completion_state`
+- `new_completion_state`
+- `missing_required_inputs`
+- `missing_optional_inputs`
+
+## Readiness Recalculation Events
+
+### `profile_readiness_recalculation_requested`
+
+Emitted when a user action or system action queues a readiness recalculation.
+
+Properties:
+
+- `trigger_event_id`
+- `trigger_reason`
+- `changed_inputs`
+
+### `profile_readiness_score_recalculated`
+
+Emitted after the readiness score is recalculated.
+
+Properties:
+
+- `score_id`
+- `previous_score`
+- `new_score`
+- `score_delta`
+- `previous_band`
+- `new_band`
+- `category_scores`
+- `category_weights`
+- `provisional_score`
+- `human_reviewed`
+- `lowest_scoring_category`
+- `calculation_version`
+
+### `profile_readiness_score_explained`
+
+Emitted when a user opens or views the explanation for a readiness score.
+
+Properties:
+
+- `score_id`
+- `band`
+- `highlighted_strength_count`
+- `highlighted_gap_count`
+- `score_history_available`
+
+## Recommendation Interaction Events
+
+### `profile_readiness_recommendations_generated`
+
+Emitted when the system generates recommended profile actions after scoring.
+
+Properties:
+
+- `score_id`
+- `recommendation_count`
+- `top_category`
+- `generation_reason`
+- `confidence`
+
+### `profile_readiness_recommendation_viewed`
+
+Emitted when a user views a specific recommendation.
+
+Properties:
+
+- `recommendation_id`
+- `score_id`
+- `category`
+- `rank`
+- `recommendation_type`
+
+### `profile_readiness_recommendation_started`
+
+Emitted when a user begins acting on a recommendation.
+
+Properties:
+
+- `recommendation_id`
+- `score_id`
+- `category`
+- `action_type`
+
+### `profile_readiness_recommendation_completed`
+
+Emitted when a user marks a recommendation complete or the system detects completion.
+
+Properties:
+
+- `recommendation_id`
+- `score_id`
+- `category`
+- `completion_source`
+- `recalculation_requested`
+
+## Privacy Expectations
+
+Events must not include raw resume text, raw LinkedIn profile text, recruiter notes, mentor notes, email addresses, phone numbers, or external profile URLs. Store references to internal document or review identifiers when later inspection is needed.


### PR DESCRIPTION
Summary:
- Link the root README to the profile readiness documentation pack.
- Add first-prototype docs for readiness scope, scoring, tracking events, recommendation interactions, and acceptance scenarios.

Checks:
- git diff --check -- README.md docs/profile-readiness
- find docs/profile-readiness -maxdepth 1 -type f | sort
- rg -n '/Users/|API[_ -]?key|secret|token|password|BEGIN (RSA|OPENSSH|PRIVATE)' README.md docs/profile-readiness (no matches)