### PR TITLE
GURU-104: Build profile readiness scoring documentation pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ Run the local Streamlit prototype to explore:
 - auto-scheduled prep sessions
 - mock interview tracking
 - profile readiness scoring
+  - Inputs: resume ATS compliance, formatting, impact, LinkedIn profile feedback, and optional mentor/recruiter review notes
+  - Output: profile readiness score summarizing resume & LinkedIn profile strength before prep
+  - Output: tracked readiness changes highlighting priority gaps for users to address
 - salary negotiation support prompts
 
 Command:
 `streamlit run gurukul_quick_app.py`
-
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Optional 1:1 review with mentor/recruiter
 
 Score and track profile readiness
 
+Supporting spec: [Profile readiness documentation pack](docs/profile-readiness/README.md) for first-prototype scoring, signals, and acceptance criteria
+
 🛣️ 1. Personalized Roadmap Creation
 User defines target role (e.g., SDE, PM) and time frame (e.g., 30 days)
 
@@ -70,4 +72,3 @@ Run the local Streamlit prototype to explore:
 
 Command:
 `streamlit run gurukul_quick_app.py`
-

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Match internal mentor availability for booked 1:1 sessions
 
 Dynamic adjustments for missed or rescheduled tasks
 
+Missed solo tasks move to the next open prep slot within the user's availability, shifting later unscheduled work only when needed
+
+Missed or rescheduled mentor sessions keep mentor availability as the scheduling constraint: release the missed booking, show matching internal mentor availability, and require user confirmation before booking a new 1:1 session
+
 🧪 4. Mock Exams & Interviews
 DSA/technical mock tests with scoring, timing, and analytics
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Optional 1:1 review with mentor/recruiter
 
 Score and track profile readiness
 
-Supporting spec: [Profile readiness documentation pack](docs/profile-readiness/README.md) for first-prototype scoring, signals, and acceptance criteria
+Supporting spec: [Profile readiness documentation pack](docs/profile-readiness/README.md) for first-prototype scoring, signals and events, accepted behaviors, and privacy expectations
 
 🛣️ 1. Personalized Roadmap Creation
 User defines target role (e.g., SDE, PM) and time frame (e.g., 30 days)

--- a/docs/profile-readiness/README.md
+++ b/docs/profile-readiness/README.md
@@ -1,0 +1,34 @@
+# Profile Readiness Documentation
+
+This documentation pack supports the Profile & Application Readiness area of Gurukul's product scope. The root [README](../../README.md) remains the source of truth for the overall product; these docs define the first-prototype behavior for calculating, explaining, and tracking profile readiness before prep begins.
+
+## User Problem
+
+Candidates often enter interview prep with uneven resume quality, incomplete LinkedIn information, unclear evidence of impact, or no recruiter/mentor review. Gurukul should help users understand how ready their profile is, which gaps matter most, and what actions can improve their readiness score before they spend time on roadmap tasks, mock exams, or salary negotiation support.
+
+## First Prototype Scope
+
+The first prototype should:
+
+- calculate a profile readiness score from resume ATS compliance, formatting, impact, LinkedIn profile feedback, and optional mentor/recruiter review notes;
+- show the score as a readiness band with a short explanation of the strongest and weakest categories;
+- track score changes after profile imports, manual edits, feedback updates, or mentor/recruiter review notes;
+- recommend the next best profile actions based on the largest weighted readiness gaps;
+- preserve enough scoring context to explain why the score changed.
+
+## Out Of Scope
+
+The first prototype should not:
+
+- guarantee job application outcomes or interview callbacks;
+- replace human mentor/recruiter judgment;
+- automatically submit resumes, LinkedIn updates, or job applications;
+- scrape private LinkedIn data without explicit user action;
+- compare users against named peers or expose another user's profile signals;
+- calculate interview readiness scoring, which remains part of Mock Exams & Interviews.
+
+## Supporting Docs
+
+- [Scoring model](scoring-model.md) defines categories, inputs, weights, readiness bands, and edge cases.
+- [Signals and events](signals-and-events.md) defines the tracking events needed for imports, recalculation, and recommendation interactions.
+- [Acceptance criteria](acceptance-criteria.md) defines user-facing scenarios for prototype acceptance.

--- a/docs/profile-readiness/README.md
+++ b/docs/profile-readiness/README.md
@@ -14,7 +14,8 @@ The first prototype should:
 - show the score as a readiness band with a short explanation of the strongest and weakest categories;
 - track score changes after profile imports, manual edits, feedback updates, or mentor/recruiter review notes;
 - recommend the next best profile actions based on the largest weighted readiness gaps;
-- preserve enough scoring context to explain why the score changed.
+- preserve enough scoring context to explain why the score changed;
+- keep analytics events focused on scoring metadata instead of raw resume, LinkedIn, or review content.
 
 ## Out Of Scope
 
@@ -25,7 +26,8 @@ The first prototype should not:
 - automatically submit resumes, LinkedIn updates, or job applications;
 - scrape private LinkedIn data without explicit user action;
 - compare users against named peers or expose another user's profile signals;
-- calculate interview readiness scoring, which remains part of Mock Exams & Interviews.
+- calculate interview readiness scoring, which remains part of Mock Exams & Interviews;
+- expand or replace the product scope defined in the root README.
 
 ## Supporting Docs
 

--- a/docs/profile-readiness/acceptance-criteria.md
+++ b/docs/profile-readiness/acceptance-criteria.md
@@ -1,6 +1,6 @@
 # Profile Readiness Acceptance Criteria
 
-These scenarios define expected user-facing behavior for the first profile readiness scoring prototype. They support the root [README](../../README.md) and do not replace its product scope.
+These scenarios define expected user-facing behavior for the first profile readiness scoring prototype. They support the root [README](../../README.md) and do not replace its product scope. They are acceptance checks for product behavior, not an implementation mandate for a specific UI layout.
 
 ## Scenarios
 
@@ -51,3 +51,7 @@ Given profile readiness tracking events are emitted, when event payloads are ins
 ### 12. Score History Explains Changes Over Time
 
 Given a user has multiple readiness recalculations, when they view score history, then Gurukul shows each score, band, score delta, trigger reason, and changed category without exposing private profile content.
+
+### 13. Privacy Expectations Are Visible To The User
+
+Given a user is asked to add resume, LinkedIn, or mentor/recruiter review information, when they review profile readiness, then Gurukul explains that recommendations use profile signals and does not imply that private content is shared with other users.

--- a/docs/profile-readiness/acceptance-criteria.md
+++ b/docs/profile-readiness/acceptance-criteria.md
@@ -1,0 +1,53 @@
+# Profile Readiness Acceptance Criteria
+
+These scenarios define expected user-facing behavior for the first profile readiness scoring prototype. They support the root [README](../../README.md) and do not replace its product scope.
+
+## Scenarios
+
+### 1. Resume Import Creates An Initial Score
+
+Given a user uploads a parseable resume, when analysis completes, then Gurukul shows a profile readiness score, readiness band, category breakdown, and at least one recommended next action.
+
+### 2. Missing Resume Shows An Empty State
+
+Given a user has not uploaded or imported a resume, when they open profile readiness, then Gurukul does not show a numeric score and prompts the user to upload or import a resume.
+
+### 3. Unparseable Resume Explains The Blocker
+
+Given a user uploads a resume that cannot be parsed, when analysis completes, then Gurukul explains that the file could not be read reliably, caps ATS compliance, withholds impact scoring, and recommends uploading a parseable file.
+
+### 4. Missing LinkedIn Feedback Shows A Provisional Score
+
+Given a user has a scored resume but no LinkedIn feedback, when they view readiness, then Gurukul shows a provisional score, identifies LinkedIn profile feedback as missing, and prompts the user to add or skip LinkedIn information.
+
+### 5. Manual Profile Updates Can Change The Score
+
+Given a user edits resume or LinkedIn feedback inputs, when readiness is recalculated, then Gurukul shows the new score, score delta, updated band when applicable, and the category that changed most.
+
+### 6. Mentor Or Recruiter Review Adds Human Context
+
+Given a mentor or recruiter adds review notes, when readiness is recalculated, then Gurukul includes the mentor/recruiter review category, marks the score as human-reviewed, and updates recommendations based on priority gaps from the review.
+
+### 7. Recommendations Prioritize The Largest Gap
+
+Given multiple categories have issues, when recommendations are generated, then Gurukul ranks the largest weighted readiness gap first and explains why that action is expected to improve readiness.
+
+### 8. Completed Recommendations Trigger Recalculation
+
+Given a user completes a recommended profile action, when completion is saved, then Gurukul requests a readiness recalculation and shows whether the score changed after the update.
+
+### 9. Target Role Changes Reframe Role Alignment
+
+Given a user changes their target role, when readiness is recalculated, then Gurukul updates role relevance inputs, preserves score history, and explains that the score changed because the target role changed.
+
+### 10. Duplicate Imports Do Not Create False Progress
+
+Given a user imports the same resume or LinkedIn feedback without changes, when analysis runs, then Gurukul identifies it as a duplicate import, keeps the existing score, and does not show a score increase.
+
+### 11. Privacy-Sensitive Content Is Not Exposed In Events
+
+Given profile readiness tracking events are emitted, when event payloads are inspected, then they contain identifiers and scoring metadata but no raw resume text, raw LinkedIn profile text, mentor/recruiter notes, contact information, or external profile URLs.
+
+### 12. Score History Explains Changes Over Time
+
+Given a user has multiple readiness recalculations, when they view score history, then Gurukul shows each score, band, score delta, trigger reason, and changed category without exposing private profile content.

--- a/docs/profile-readiness/scoring-model.md
+++ b/docs/profile-readiness/scoring-model.md
@@ -13,6 +13,7 @@ This model defines how the first prototype calculates the profile readiness scor
 | Mentor/recruiter review | 10% | Incorporates optional qualitative feedback from a mentor or recruiter. |
 
 Weights must sum to 100%. Category scores use a 0 to 100 scale before weighting.
+The first prototype should treat these weights as `calculation_version` 1 so future model changes can be explained in score history without rewriting older scores.
 
 ## Inputs
 
@@ -64,3 +65,4 @@ The interface should display both the numeric score and the readiness band. Reco
 - Target role changes: recalculate role relevance inputs and create a score history entry explaining that the target role changed.
 - Duplicate imports: ignore exact duplicate resume or LinkedIn imports and do not create a new score-change event.
 - Low confidence findings: include the score, but show that recommendations are based on limited evidence.
+- Invalid category values: clamp category scores to the 0 to 100 range before applying weights and flag the recalculation for review.

--- a/docs/profile-readiness/scoring-model.md
+++ b/docs/profile-readiness/scoring-model.md
@@ -1,0 +1,66 @@
+# Profile Readiness Scoring Model
+
+This model defines how the first prototype calculates the profile readiness score named in the root [README](../../README.md). The score summarizes resume and LinkedIn profile strength before prep and highlights priority gaps for users to address.
+
+## Score Categories
+
+| Category | Weight | Purpose |
+| --- | ---: | --- |
+| Resume ATS compliance | 30% | Measures whether the resume can be parsed and screened by applicant tracking systems. |
+| Resume formatting | 15% | Measures readability, structure, section clarity, length, and consistency. |
+| Resume impact | 25% | Measures outcome-oriented bullets, quantified achievements, role relevance, and clarity of scope. |
+| LinkedIn profile feedback | 20% | Measures completeness and alignment between LinkedIn profile, target role, and resume narrative. |
+| Mentor/recruiter review | 10% | Incorporates optional qualitative feedback from a mentor or recruiter. |
+
+Weights must sum to 100%. Category scores use a 0 to 100 scale before weighting.
+
+## Inputs
+
+The scoring model accepts these inputs:
+
+- uploaded resume text and parser metadata;
+- ATS compliance findings, including parse success, contact information presence, section detection, keyword alignment, and unsupported formatting flags;
+- formatting findings, including section order, bullet consistency, page length, tense consistency, and readability issues;
+- impact findings, including quantified outcomes, action verbs, role relevance, seniority signals, and repeated vague claims;
+- LinkedIn profile feedback entered or imported by the user, including headline, About section, experience completeness, skills, projects, and consistency with the resume;
+- optional mentor/recruiter review notes, including a rating, priority gaps, and confidence level when provided.
+
+If a target role is available from roadmap creation, role relevance should use that target role. If no target role is available, the category should use general interview-prep quality checks and clearly mark role-specific guidance as limited.
+
+## Weighted Calculation
+
+Calculate the overall readiness score with this formula:
+
+```text
+overall_score =
+  (ats_score * 0.30) +
+  (formatting_score * 0.15) +
+  (impact_score * 0.25) +
+  (linkedin_score * 0.20) +
+  (mentor_review_score * 0.10)
+```
+
+Round the final score to the nearest whole number. Store the unrounded value for change tracking so small improvements are not lost across recalculations.
+
+## Readiness Bands
+
+| Band | Score Range | User Meaning |
+| --- | ---: | --- |
+| Not ready | 0-39 | Major profile gaps block effective application prep. |
+| Needs work | 40-64 | Core profile exists, but important gaps remain. |
+| Approaching ready | 65-79 | Profile is usable, with focused improvements recommended. |
+| Ready | 80-89 | Profile is strong enough to support active prep and applications. |
+| Strong | 90-100 | Profile is polished, consistent, and role-aligned. |
+
+The interface should display both the numeric score and the readiness band. Recommendations should prioritize the largest weighted readiness gap, calculated as `(100 - category_score) * category_weight`, then the highest-impact unresolved issue within that category.
+
+## Edge Cases
+
+- No resume uploaded: return no overall score, show an empty state, and prompt the user to import or upload a resume.
+- Resume cannot be parsed: cap ATS compliance at 20, withhold impact scoring until readable text is available, and recommend uploading a parseable file.
+- Missing LinkedIn data: set LinkedIn profile feedback to 0 only after the user skips or confirms they do not want to provide it; otherwise mark it incomplete and show a provisional score.
+- No mentor/recruiter review: use a neutral default of 50 for the mentor/recruiter review category and label the score as not yet human-reviewed.
+- Conflicting mentor/recruiter review notes: use the most recent review as the active score input and preserve prior reviews in score history.
+- Target role changes: recalculate role relevance inputs and create a score history entry explaining that the target role changed.
+- Duplicate imports: ignore exact duplicate resume or LinkedIn imports and do not create a new score-change event.
+- Low confidence findings: include the score, but show that recommendations are based on limited evidence.

--- a/docs/profile-readiness/signals-and-events.md
+++ b/docs/profile-readiness/signals-and-events.md
@@ -1,4 +1,4 @@
-# Profile Readiness Signals And Events
+# Profile Readiness Signals and Events
 
 This document defines the first-prototype tracking events for profile completion, readiness recalculation, and recommendation interactions. Events should help explain score changes and support product analytics without storing unnecessary private profile content.
 
@@ -8,6 +8,7 @@ This document defines the first-prototype tracking events for profile completion
 - Use stable user, profile, and score identifiers supplied by the application layer.
 - Include source and confidence fields when a score or recommendation depends on inferred data.
 - Emit events after the user completes an action or the system completes a recalculation.
+- Keep event names scoped with the `profile_readiness_` prefix so they remain distinct from roadmap, mock interview, or salary negotiation events.
 
 ## Shared Properties
 
@@ -164,4 +165,4 @@ Properties:
 
 ## Privacy Expectations
 
-Events must not include raw resume text, raw LinkedIn profile text, recruiter notes, mentor notes, email addresses, phone numbers, or external profile URLs. Store references to internal document or review identifiers when later inspection is needed.
+Events must not include raw resume text, raw LinkedIn profile text, recruiter notes, mentor notes, email addresses, phone numbers, or external profile URLs. Store references to internal document or review identifiers when later inspection is needed, and rely on application permissions before resolving those references.

--- a/docs/profile-readiness/signals-and-events.md
+++ b/docs/profile-readiness/signals-and-events.md
@@ -1,0 +1,167 @@
+# Profile Readiness Signals And Events
+
+This document defines the first-prototype tracking events for profile completion, readiness recalculation, and recommendation interactions. Events should help explain score changes and support product analytics without storing unnecessary private profile content.
+
+## Event Principles
+
+- Track actions and scoring metadata, not raw resume text or private LinkedIn content.
+- Use stable user, profile, and score identifiers supplied by the application layer.
+- Include source and confidence fields when a score or recommendation depends on inferred data.
+- Emit events after the user completes an action or the system completes a recalculation.
+
+## Shared Properties
+
+Each event should include:
+
+| Property | Description |
+| --- | --- |
+| `event_id` | Unique identifier for the event. |
+| `user_id` | Internal user identifier. |
+| `profile_id` | Internal profile readiness record identifier. |
+| `occurred_at` | Timestamp when the event occurred. |
+| `source` | Action source, such as `resume_upload`, `linkedin_import`, `manual_edit`, `mentor_review`, or `system_recalculation`. |
+| `schema_version` | Event schema version, starting with `1`. |
+
+## Profile Completion Events
+
+### `profile_readiness_resume_imported`
+
+Emitted when a user uploads or imports a resume for readiness scoring.
+
+Properties:
+
+- `resume_document_id`
+- `file_type`
+- `parse_status`
+- `detected_sections_count`
+- `duplicate_import`
+
+### `profile_readiness_linkedin_feedback_added`
+
+Emitted when LinkedIn profile feedback is entered, imported, or updated.
+
+Properties:
+
+- `feedback_source`
+- `completion_fields_present`
+- `role_alignment_available`
+- `manual_edit`
+
+### `profile_readiness_mentor_review_added`
+
+Emitted when mentor/recruiter review notes are added or updated.
+
+Properties:
+
+- `review_id`
+- `reviewer_type`
+- `review_score`
+- `priority_gap_count`
+- `review_confidence`
+
+### `profile_readiness_completion_changed`
+
+Emitted when required or optional profile readiness inputs move between incomplete, provisional, and complete states.
+
+Properties:
+
+- `previous_completion_state`
+- `new_completion_state`
+- `missing_required_inputs`
+- `missing_optional_inputs`
+
+## Readiness Recalculation Events
+
+### `profile_readiness_recalculation_requested`
+
+Emitted when a user action or system action queues a readiness recalculation.
+
+Properties:
+
+- `trigger_event_id`
+- `trigger_reason`
+- `changed_inputs`
+
+### `profile_readiness_score_recalculated`
+
+Emitted after the readiness score is recalculated.
+
+Properties:
+
+- `score_id`
+- `previous_score`
+- `new_score`
+- `score_delta`
+- `previous_band`
+- `new_band`
+- `category_scores`
+- `category_weights`
+- `provisional_score`
+- `human_reviewed`
+- `lowest_scoring_category`
+- `calculation_version`
+
+### `profile_readiness_score_explained`
+
+Emitted when a user opens or views the explanation for a readiness score.
+
+Properties:
+
+- `score_id`
+- `band`
+- `highlighted_strength_count`
+- `highlighted_gap_count`
+- `score_history_available`
+
+## Recommendation Interaction Events
+
+### `profile_readiness_recommendations_generated`
+
+Emitted when the system generates recommended profile actions after scoring.
+
+Properties:
+
+- `score_id`
+- `recommendation_count`
+- `top_category`
+- `generation_reason`
+- `confidence`
+
+### `profile_readiness_recommendation_viewed`
+
+Emitted when a user views a specific recommendation.
+
+Properties:
+
+- `recommendation_id`
+- `score_id`
+- `category`
+- `rank`
+- `recommendation_type`
+
+### `profile_readiness_recommendation_started`
+
+Emitted when a user begins acting on a recommendation.
+
+Properties:
+
+- `recommendation_id`
+- `score_id`
+- `category`
+- `action_type`
+
+### `profile_readiness_recommendation_completed`
+
+Emitted when a user marks a recommendation complete or the system detects completion.
+
+Properties:
+
+- `recommendation_id`
+- `score_id`
+- `category`
+- `completion_source`
+- `recalculation_requested`
+
+## Privacy Expectations
+
+Events must not include raw resume text, raw LinkedIn profile text, recruiter notes, mentor notes, email addresses, phone numbers, or external profile URLs. Store references to internal document or review identifiers when later inspection is needed.

--- a/gurukul_quick_app.py
+++ b/gurukul_quick_app.py
@@ -4,6 +4,13 @@ from dataclasses import dataclass
 
 import streamlit as st
 
+from profile_readiness import (
+    CATEGORY_LABELS,
+    ProfileReadinessInput,
+    calculate_readiness,
+    generate_recommendations,
+)
+
 
 @dataclass(frozen=True)
 class RoadmapWeek:
@@ -57,11 +64,6 @@ def build_roadmap(role: str, weeks: int, skill_level: str) -> list[RoadmapWeek]:
     return roadmap
 
 
-def readiness_score(resume_score: int, linkedin_score: int, mocks_completed: int, hours_per_week: int) -> int:
-    score = resume_score * 0.3 + linkedin_score * 0.2 + min(mocks_completed, 5) * 10 + min(hours_per_week, 15) * 2
-    return min(int(score), 100)
-
-
 def daily_schedule(hours_per_week: int) -> list[str]:
     days = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
     base = max(hours_per_week // len(days), 1)
@@ -76,7 +78,7 @@ def daily_schedule(hours_per_week: int) -> list[str]:
 st.set_page_config(page_title="Gurukul Quick App", page_icon="🎯", layout="wide")
 
 st.title("🎯 Gurukul Quick App")
-st.caption("Prototype for personalized roadmap creation, resource mapping, scheduling, and interview readiness scoring.")
+st.caption("Prototype for personalized roadmap creation, resource mapping, scheduling, and profile readiness scoring.")
 
 with st.sidebar:
     st.header("User Inputs")
@@ -84,18 +86,64 @@ with st.sidebar:
     timeline_days = st.slider("Prep timeline (days)", min_value=14, max_value=90, value=30, step=7)
     hours_per_week = st.slider("Available prep hours per week", min_value=3, max_value=25, value=8)
     skill_level = st.selectbox("Current skill level", ["Beginner", "Intermediate", "Advanced"])
-    resume_score = st.slider("Resume readiness", min_value=0, max_value=100, value=68)
-    linkedin_score = st.slider("LinkedIn readiness", min_value=0, max_value=100, value=61)
+
+    st.header("Profile Readiness Inputs")
+    resume_uploaded = st.checkbox("Resume imported for scoring", value=True)
+    if resume_uploaded:
+        resume_parseable = st.checkbox("Resume can be parsed", value=True)
+        ats_score = st.slider("Resume ATS compliance", min_value=0, max_value=100, value=68)
+        formatting_score = st.slider("Resume formatting", min_value=0, max_value=100, value=72)
+        impact_score = (
+            st.slider("Resume impact", min_value=0, max_value=100, value=64)
+            if resume_parseable
+            else None
+        )
+    else:
+        resume_parseable = False
+        ats_score = None
+        formatting_score = None
+        impact_score = None
+
+    linkedin_feedback_available = st.checkbox("LinkedIn feedback available", value=True)
+    if linkedin_feedback_available:
+        linkedin_score = st.slider("LinkedIn profile feedback", min_value=0, max_value=100, value=61)
+        linkedin_confirmed_missing = False
+    else:
+        linkedin_score = None
+        linkedin_confirmed_missing = st.checkbox("User skipped LinkedIn feedback", value=False)
+
+    mentor_review_available = st.checkbox("Mentor/recruiter review provided", value=False)
+    mentor_review_score = (
+        st.slider("Mentor/recruiter review", min_value=0, max_value=100, value=70)
+        if mentor_review_available
+        else None
+    )
     mocks_completed = st.slider("Mock exams & interviews completed", min_value=0, max_value=10, value=1)
 
 weeks = max(timeline_days // 7, 2)
 roadmap = build_roadmap(role, weeks, skill_level)
-score = readiness_score(resume_score, linkedin_score, mocks_completed, hours_per_week)
+readiness = calculate_readiness(
+    ProfileReadinessInput(
+        ats_score=ats_score,
+        formatting_score=formatting_score,
+        impact_score=impact_score,
+        linkedin_score=linkedin_score,
+        mentor_review_score=mentor_review_score,
+        resume_uploaded=resume_uploaded,
+        resume_parseable=resume_parseable,
+        linkedin_confirmed_missing=linkedin_confirmed_missing,
+    )
+)
+recommendations = generate_recommendations(readiness)
 resources = ROLE_RESOURCES[role]
 schedule = daily_schedule(hours_per_week)
 
 metric_col_1, metric_col_2, metric_col_3, metric_col_4 = st.columns(4)
-metric_col_1.metric("Interview readiness", f"{score}/100")
+metric_col_1.metric(
+    "Profile readiness",
+    f"{readiness.score}/100" if readiness.score is not None else "Not scored",
+    readiness.readiness_band or "Resume needed",
+)
 metric_col_2.metric("Roadmap length", f"{weeks} weeks")
 metric_col_3.metric("Resource matches", len(resources))
 metric_col_4.metric("Weekly prep hours", hours_per_week)
@@ -120,13 +168,39 @@ with right_col:
         st.write(f"- {item}")
 
     st.subheader("Resume & LinkedIn Optimization")
-    st.progress(score / 100)
-    if score < 50:
-        st.warning("Profile readiness is low. Prioritize resume updates and mentor feedback before increasing mock intensity.")
-    elif score < 75:
-        st.info("Profile readiness is improving. Continue profile updates alongside weekly mock interviews.")
+    if readiness.score is None:
+        st.info("Import or upload a resume to calculate profile readiness.")
     else:
-        st.success("Profile readiness is strong. Shift more time toward mock interviews and salary negotiation support.")
+        st.progress(readiness.score / 100)
+        st.write(f"**Readiness band:** {readiness.readiness_band}")
+        if readiness.top_gap_label:
+            top_gap = readiness.weighted_gaps[readiness.top_gap_category]
+            st.write(f"**Top gap:** {readiness.top_gap_label} ({top_gap:g} weighted points)")
+
+        if readiness.provisional:
+            st.warning("This score is provisional because one or more profile readiness inputs are incomplete.")
+        elif readiness.score < 65:
+            st.warning("Profile readiness has important gaps. Prioritize profile updates before increasing mock intensity.")
+        elif readiness.score < 80:
+            st.info("Profile readiness is improving. Continue profile updates alongside weekly mock interviews.")
+        else:
+            st.success("Profile readiness is strong. Shift more time toward mock interviews and salary negotiation support.")
+
+        if readiness.human_reviewed:
+            st.caption("Includes mentor/recruiter review input.")
+        else:
+            st.caption("Mentor/recruiter review uses a neutral default until human feedback is provided.")
+
+    st.markdown("**Recommended next actions**")
+    for recommendation in recommendations:
+        st.write(f"{recommendation.rank}. {recommendation.action}")
+
+    with st.expander("Category breakdown"):
+        for category, label in CATEGORY_LABELS.items():
+            score_value = readiness.category_scores[category]
+            score_display = "Incomplete" if score_value is None else f"{score_value}/100"
+            gap = readiness.weighted_gaps[category]
+            st.write(f"**{label}:** {score_display} · weighted gap {gap:g}")
 
     st.subheader("Mock Exams & Interviews")
     st.write(
@@ -135,7 +209,13 @@ with right_col:
     )
 
     st.subheader("Salary Negotiation Support")
-    st.write(
-        "When readiness is above 70, add a final-week negotiation session covering offer benchmarking, "
-        "email scripts, and peer comparisons."
-    )
+    if readiness.score is not None and readiness.score > 70:
+        st.write(
+            "Profile readiness is above 70. Add a final-week negotiation session covering offer benchmarking, "
+            "email scripts, and peer comparisons."
+        )
+    else:
+        st.write(
+            "Raise profile readiness above 70 before adding a final-week negotiation session with offer benchmarking, "
+            "email scripts, and peer comparisons."
+        )

--- a/gurukul_quick_app.py
+++ b/gurukul_quick_app.py
@@ -6,9 +6,13 @@ import streamlit as st
 
 from profile_readiness import (
     CATEGORY_LABELS,
+    HISTORY_SESSION_KEY,
     ProfileReadinessInput,
+    append_history_entry,
     calculate_readiness,
     generate_recommendations,
+    latest_score_delta,
+    recent_history_entries,
 )
 
 
@@ -75,6 +79,82 @@ def daily_schedule(hours_per_week: int) -> list[str]:
     return plan
 
 
+def profile_readiness_snapshot(
+    *,
+    resume_uploaded: bool,
+    resume_parseable: bool,
+    ats_score: int | None,
+    formatting_score: int | None,
+    impact_score: int | None,
+    linkedin_feedback_available: bool,
+    linkedin_score: int | None,
+    linkedin_confirmed_missing: bool,
+    mentor_review_available: bool,
+    mentor_review_score: int | None,
+) -> tuple[tuple[str, int | bool | None], ...]:
+    return (
+        ("resume_uploaded", resume_uploaded),
+        ("resume_parseable", resume_parseable),
+        ("ats_score", ats_score),
+        ("formatting_score", formatting_score),
+        ("impact_score", impact_score),
+        ("linkedin_feedback_available", linkedin_feedback_available),
+        ("linkedin_score", linkedin_score),
+        ("linkedin_confirmed_missing", linkedin_confirmed_missing),
+        ("mentor_review_available", mentor_review_available),
+        ("mentor_review_score", mentor_review_score),
+    )
+
+
+def history_trigger_reason(
+    previous_snapshot: tuple[tuple[str, int | bool | None], ...] | None,
+    current_snapshot: tuple[tuple[str, int | bool | None], ...],
+) -> str:
+    if previous_snapshot is None:
+        return "initial_calculation"
+
+    previous = dict(previous_snapshot)
+    current = dict(current_snapshot)
+    changed_inputs = {
+        key
+        for key, value in current.items()
+        if previous.get(key) != value
+    }
+    changed_groups = []
+    if changed_inputs & {"resume_uploaded", "resume_parseable", "ats_score", "formatting_score", "impact_score"}:
+        changed_groups.append("resume")
+    if changed_inputs & {"linkedin_feedback_available", "linkedin_score", "linkedin_confirmed_missing"}:
+        changed_groups.append("linkedin")
+    if changed_inputs & {"mentor_review_available", "mentor_review_score"}:
+        changed_groups.append("mentor_recruiter_review")
+
+    if not changed_groups:
+        return "profile_recalculated"
+    return f"{'_'.join(changed_groups)}_update"
+
+
+def score_delta_label(delta: int | None) -> str | None:
+    if delta is None:
+        return None
+    if delta > 0:
+        return f"+{delta} since previous score"
+    return f"{delta} since previous score"
+
+
+def history_entry_line(entry) -> str:
+    score_display = "Not scored" if entry.score is None else f"{entry.score}/100"
+    band_display = entry.readiness_band or "Resume needed"
+    gap_display = CATEGORY_LABELS.get(entry.top_gap_category, "No top gap")
+    review_display = "human reviewed" if entry.human_reviewed else "human review default"
+    provisional_display = "provisional" if entry.provisional else "final"
+    trigger_display = entry.trigger_reason.replace("_", " ")
+    return (
+        f"- {entry.timestamp}: {score_display} · {band_display} · "
+        f"top gap: {gap_display} · {provisional_display} · "
+        f"{review_display} · {trigger_display}"
+    )
+
+
 st.set_page_config(page_title="Gurukul Quick App", page_icon="🎯", layout="wide")
 
 st.title("🎯 Gurukul Quick App")
@@ -134,6 +214,28 @@ readiness = calculate_readiness(
         linkedin_confirmed_missing=linkedin_confirmed_missing,
     )
 )
+readiness_snapshot = profile_readiness_snapshot(
+    resume_uploaded=resume_uploaded,
+    resume_parseable=resume_parseable,
+    ats_score=ats_score,
+    formatting_score=formatting_score,
+    impact_score=impact_score,
+    linkedin_feedback_available=linkedin_feedback_available,
+    linkedin_score=linkedin_score,
+    linkedin_confirmed_missing=linkedin_confirmed_missing,
+    mentor_review_available=mentor_review_available,
+    mentor_review_score=mentor_review_score,
+)
+previous_readiness_snapshot = st.session_state.get("profile_readiness_history_snapshot")
+if previous_readiness_snapshot != readiness_snapshot:
+    append_history_entry(
+        st.session_state,
+        readiness,
+        trigger_reason=history_trigger_reason(previous_readiness_snapshot, readiness_snapshot),
+    )
+    st.session_state["profile_readiness_history_snapshot"] = readiness_snapshot
+readiness_history = recent_history_entries(st.session_state, limit=5)
+readiness_score_delta = latest_score_delta(st.session_state.get(HISTORY_SESSION_KEY, []))
 recommendations = generate_recommendations(readiness)
 resources = ROLE_RESOURCES[role]
 schedule = daily_schedule(hours_per_week)
@@ -142,7 +244,7 @@ metric_col_1, metric_col_2, metric_col_3, metric_col_4 = st.columns(4)
 metric_col_1.metric(
     "Profile readiness",
     f"{readiness.score}/100" if readiness.score is not None else "Not scored",
-    readiness.readiness_band or "Resume needed",
+    score_delta_label(readiness_score_delta) or readiness.readiness_band or "Resume needed",
 )
 metric_col_2.metric("Roadmap length", f"{weeks} weeks")
 metric_col_3.metric("Resource matches", len(resources))
@@ -190,6 +292,14 @@ with right_col:
             st.caption("Includes mentor/recruiter review input.")
         else:
             st.caption("Mentor/recruiter review uses a neutral default until human feedback is provided.")
+
+    st.markdown("**Recent readiness history**")
+    if readiness_score_delta is None:
+        st.caption("No previous scored recalculation yet.")
+    else:
+        st.caption(f"Score change from the previous scored recalculation: {readiness_score_delta:+d}.")
+    for history_entry in readiness_history:
+        st.write(history_entry_line(history_entry))
 
     st.markdown("**Recommended next actions**")
     for recommendation in recommendations:

--- a/profile_readiness/__init__.py
+++ b/profile_readiness/__init__.py
@@ -1,0 +1,34 @@
+from .events import (
+    build_recalculation_requested_event,
+    build_recommendation_completed_event,
+    build_recommendation_started_event,
+    build_recommendation_viewed_event,
+    build_recommendations_generated_event,
+    build_score_recalculated_event,
+)
+from .recommendations import Recommendation, generate_recommendations
+from .scoring import (
+    CATEGORY_LABELS,
+    CATEGORY_WEIGHTS,
+    ProfileReadinessInput,
+    ProfileReadinessResult,
+    calculate_readiness,
+    readiness_band_for_score,
+)
+
+__all__ = [
+    "CATEGORY_LABELS",
+    "CATEGORY_WEIGHTS",
+    "ProfileReadinessInput",
+    "ProfileReadinessResult",
+    "Recommendation",
+    "build_recalculation_requested_event",
+    "build_recommendation_completed_event",
+    "build_recommendation_started_event",
+    "build_recommendation_viewed_event",
+    "build_recommendations_generated_event",
+    "build_score_recalculated_event",
+    "calculate_readiness",
+    "generate_recommendations",
+    "readiness_band_for_score",
+]

--- a/profile_readiness/__init__.py
+++ b/profile_readiness/__init__.py
@@ -6,6 +6,14 @@ from .events import (
     build_recommendations_generated_event,
     build_score_recalculated_event,
 )
+from .history import (
+    HISTORY_SESSION_KEY,
+    ProfileReadinessHistoryEntry,
+    append_history_entry,
+    build_history_entry,
+    latest_score_delta,
+    recent_history_entries,
+)
 from .recommendations import Recommendation, generate_recommendations
 from .scoring import (
     CATEGORY_LABELS,
@@ -19,9 +27,13 @@ from .scoring import (
 __all__ = [
     "CATEGORY_LABELS",
     "CATEGORY_WEIGHTS",
+    "HISTORY_SESSION_KEY",
+    "ProfileReadinessHistoryEntry",
     "ProfileReadinessInput",
     "ProfileReadinessResult",
     "Recommendation",
+    "append_history_entry",
+    "build_history_entry",
     "build_recalculation_requested_event",
     "build_recommendation_completed_event",
     "build_recommendation_started_event",
@@ -30,5 +42,7 @@ __all__ = [
     "build_score_recalculated_event",
     "calculate_readiness",
     "generate_recommendations",
+    "latest_score_delta",
     "readiness_band_for_score",
+    "recent_history_entries",
 ]

--- a/profile_readiness/events.py
+++ b/profile_readiness/events.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+from uuid import uuid4
+
+from .recommendations import Recommendation
+from .scoring import ProfileReadinessResult
+
+
+SCHEMA_VERSION = 1
+
+_PRIVATE_FIELD_MARKERS = (
+    "raw_resume",
+    "resume_text",
+    "raw_linkedin",
+    "linkedin_text",
+    "contact_information",
+    "contact_info",
+    "email",
+    "phone",
+    "external_profile_url",
+    "profile_url",
+    "mentor_notes",
+    "recruiter_notes",
+)
+
+
+def build_recalculation_requested_event(
+    *,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    trigger_event_id: str,
+    trigger_reason: str,
+    changed_inputs: Iterable[str],
+    event_id: str | None = None,
+    occurred_at: datetime | str | None = None,
+) -> dict:
+    event = _base_event(
+        "profile_readiness_recalculation_requested",
+        user_id,
+        profile_id,
+        source,
+        event_id,
+        occurred_at,
+    )
+    event.update(
+        {
+            "trigger_event_id": trigger_event_id,
+            "trigger_reason": trigger_reason,
+            "changed_inputs": _safe_changed_inputs(changed_inputs),
+        }
+    )
+    return event
+
+
+def build_score_recalculated_event(
+    *,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    score_id: str,
+    previous_result: ProfileReadinessResult | None,
+    new_result: ProfileReadinessResult,
+    event_id: str | None = None,
+    occurred_at: datetime | str | None = None,
+) -> dict:
+    previous_score = previous_result.score if previous_result else None
+    new_score = new_result.score
+    score_delta = (
+        new_score - previous_score
+        if previous_score is not None and new_score is not None
+        else None
+    )
+
+    event = _base_event(
+        "profile_readiness_score_recalculated",
+        user_id,
+        profile_id,
+        source,
+        event_id,
+        occurred_at,
+    )
+    event.update(
+        {
+            "score_id": score_id,
+            "previous_score": previous_score,
+            "new_score": new_score,
+            "score_delta": score_delta,
+            "previous_band": previous_result.readiness_band if previous_result else None,
+            "new_band": new_result.readiness_band,
+            "category_scores": dict(new_result.category_scores),
+            "category_weights": dict(new_result.category_weights),
+            "provisional_score": new_result.provisional,
+            "human_reviewed": new_result.human_reviewed,
+            "lowest_scoring_category": new_result.lowest_scoring_category,
+            "calculation_version": new_result.calculation_version,
+        }
+    )
+    return event
+
+
+def build_recommendations_generated_event(
+    *,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    score_id: str,
+    recommendations: Sequence[Recommendation],
+    generation_reason: str,
+    confidence: str,
+    event_id: str | None = None,
+    occurred_at: datetime | str | None = None,
+) -> dict:
+    event = _base_event(
+        "profile_readiness_recommendations_generated",
+        user_id,
+        profile_id,
+        source,
+        event_id,
+        occurred_at,
+    )
+    event.update(
+        {
+            "score_id": score_id,
+            "recommendation_count": len(recommendations),
+            "top_category": recommendations[0].category if recommendations else None,
+            "generation_reason": generation_reason,
+            "confidence": confidence,
+        }
+    )
+    return event
+
+
+def build_recommendation_viewed_event(
+    *,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    recommendation: Recommendation,
+    score_id: str,
+    event_id: str | None = None,
+    occurred_at: datetime | str | None = None,
+) -> dict:
+    event = _base_event(
+        "profile_readiness_recommendation_viewed",
+        user_id,
+        profile_id,
+        source,
+        event_id,
+        occurred_at,
+    )
+    event.update(
+        {
+            "recommendation_id": recommendation.recommendation_id,
+            "score_id": score_id,
+            "category": recommendation.category,
+            "rank": recommendation.rank,
+            "recommendation_type": recommendation.recommendation_type,
+        }
+    )
+    return event
+
+
+def build_recommendation_started_event(
+    *,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    recommendation: Recommendation,
+    score_id: str,
+    action_type: str,
+    event_id: str | None = None,
+    occurred_at: datetime | str | None = None,
+) -> dict:
+    event = _base_event(
+        "profile_readiness_recommendation_started",
+        user_id,
+        profile_id,
+        source,
+        event_id,
+        occurred_at,
+    )
+    event.update(
+        {
+            "recommendation_id": recommendation.recommendation_id,
+            "score_id": score_id,
+            "category": recommendation.category,
+            "action_type": action_type,
+        }
+    )
+    return event
+
+
+def build_recommendation_completed_event(
+    *,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    recommendation: Recommendation,
+    score_id: str,
+    completion_source: str,
+    recalculation_requested: bool,
+    event_id: str | None = None,
+    occurred_at: datetime | str | None = None,
+) -> dict:
+    event = _base_event(
+        "profile_readiness_recommendation_completed",
+        user_id,
+        profile_id,
+        source,
+        event_id,
+        occurred_at,
+    )
+    event.update(
+        {
+            "recommendation_id": recommendation.recommendation_id,
+            "score_id": score_id,
+            "category": recommendation.category,
+            "completion_source": completion_source,
+            "recalculation_requested": recalculation_requested,
+        }
+    )
+    return event
+
+
+def _base_event(
+    event_name: str,
+    user_id: str,
+    profile_id: str,
+    source: str,
+    event_id: str | None,
+    occurred_at: datetime | str | None,
+) -> dict:
+    return {
+        "event_name": event_name,
+        "event_id": event_id or str(uuid4()),
+        "user_id": user_id,
+        "profile_id": profile_id,
+        "occurred_at": _format_occurred_at(occurred_at),
+        "source": source,
+        "schema_version": SCHEMA_VERSION,
+    }
+
+
+def _format_occurred_at(occurred_at: datetime | str | None) -> str:
+    if occurred_at is None:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    if isinstance(occurred_at, datetime):
+        timestamp = occurred_at
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return timestamp.isoformat()
+    return occurred_at
+
+
+def _safe_changed_inputs(changed_inputs: Iterable[str]) -> list[str]:
+    safe_inputs = []
+    for changed_input in changed_inputs:
+        if not isinstance(changed_input, str):
+            continue
+        normalized = changed_input.strip()
+        if normalized and not _looks_private_field(normalized):
+            safe_inputs.append(normalized)
+    return safe_inputs
+
+
+def _looks_private_field(field_name: str) -> bool:
+    normalized = field_name.lower()
+    return any(marker in normalized for marker in _PRIVATE_FIELD_MARKERS)

--- a/profile_readiness/history.py
+++ b/profile_readiness/history.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+import re
+from typing import Any
+
+from .scoring import ProfileReadinessResult
+
+
+HISTORY_SESSION_KEY = "profile_readiness_score_history"
+DEFAULT_TRIGGER_REASON = "profile_recalculated"
+
+_SAFE_TRIGGER_REASON = re.compile(r"^[a-z0-9_:-]{1,80}$")
+_PRIVATE_FIELD_MARKERS = (
+    "raw_resume",
+    "resume_text",
+    "raw_linkedin",
+    "linkedin_text",
+    "contact_information",
+    "contact_info",
+    "email",
+    "phone",
+    "external_profile_url",
+    "profile_url",
+    "mentor_notes",
+    "recruiter_notes",
+)
+
+
+@dataclass(frozen=True)
+class ProfileReadinessHistoryEntry:
+    score: int | None
+    readiness_band: str | None
+    top_gap_category: str | None
+    provisional: bool
+    human_reviewed: bool
+    trigger_reason: str
+    timestamp: str
+
+    def as_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def append_history_entry(
+    session_state: MutableMapping[str, Any],
+    result: ProfileReadinessResult,
+    *,
+    trigger_reason: str,
+    timestamp: datetime | str | None = None,
+    session_key: str = HISTORY_SESSION_KEY,
+) -> ProfileReadinessHistoryEntry:
+    entry = build_history_entry(result, trigger_reason=trigger_reason, timestamp=timestamp)
+    history = list(session_state.get(session_key, []))
+    history.append(entry)
+    session_state[session_key] = history
+    return entry
+
+
+def build_history_entry(
+    result: ProfileReadinessResult,
+    *,
+    trigger_reason: str,
+    timestamp: datetime | str | None = None,
+) -> ProfileReadinessHistoryEntry:
+    return ProfileReadinessHistoryEntry(
+        score=result.score,
+        readiness_band=result.readiness_band,
+        top_gap_category=result.top_gap_category,
+        provisional=result.provisional,
+        human_reviewed=result.human_reviewed,
+        trigger_reason=_safe_trigger_reason(trigger_reason),
+        timestamp=_format_timestamp(timestamp),
+    )
+
+
+def recent_history_entries(
+    session_state: MutableMapping[str, Any],
+    *,
+    limit: int = 5,
+    session_key: str = HISTORY_SESSION_KEY,
+) -> list[ProfileReadinessHistoryEntry]:
+    if limit <= 0:
+        return []
+    history = list(session_state.get(session_key, []))
+    return history[-limit:]
+
+
+def latest_score_delta(entries: Sequence[ProfileReadinessHistoryEntry]) -> int | None:
+    if not entries:
+        return None
+
+    latest_entry = entries[-1]
+    if latest_entry.score is None:
+        return None
+
+    for previous_entry in reversed(entries[:-1]):
+        if previous_entry.score is not None:
+            return latest_entry.score - previous_entry.score
+    return None
+
+
+def _format_timestamp(timestamp: datetime | str | None) -> str:
+    if timestamp is None:
+        return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    if isinstance(timestamp, datetime):
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        return timestamp.isoformat()
+    return timestamp
+
+
+def _safe_trigger_reason(trigger_reason: str) -> str:
+    normalized = trigger_reason.strip().lower()
+    if not normalized:
+        return DEFAULT_TRIGGER_REASON
+    if any(marker in normalized for marker in _PRIVATE_FIELD_MARKERS):
+        return DEFAULT_TRIGGER_REASON
+    if not _SAFE_TRIGGER_REASON.fullmatch(normalized):
+        return DEFAULT_TRIGGER_REASON
+    return normalized

--- a/profile_readiness/recommendations.py
+++ b/profile_readiness/recommendations.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .scoring import (
+    CATEGORY_ATS,
+    CATEGORY_FORMATTING,
+    CATEGORY_IMPACT,
+    CATEGORY_LABELS,
+    CATEGORY_LINKEDIN,
+    CATEGORY_MENTOR_REVIEW,
+    ProfileReadinessResult,
+    rank_categories_by_weighted_gap,
+)
+
+
+@dataclass(frozen=True)
+class Recommendation:
+    recommendation_id: str
+    category: str
+    category_label: str
+    rank: int
+    action: str
+    rationale: str
+    recommendation_type: str
+
+
+def generate_recommendations(
+    result: ProfileReadinessResult, limit: int = 3
+) -> list[Recommendation]:
+    if result.score is None:
+        return [
+            Recommendation(
+                recommendation_id="profile-readiness-1-resume-import",
+                category=CATEGORY_ATS,
+                category_label=CATEGORY_LABELS[CATEGORY_ATS],
+                rank=1,
+                action="Import or upload a parseable resume to start profile readiness scoring.",
+                rationale="No resume is available, so Gurukul cannot calculate the documented readiness score.",
+                recommendation_type="resume_import",
+            )
+        ]
+
+    recommendations: list[Recommendation] = []
+    for category in rank_categories_by_weighted_gap(result):
+        if result.weighted_gaps[category] <= 0:
+            continue
+        rank = len(recommendations) + 1
+        recommendations.append(
+            Recommendation(
+                recommendation_id=f"profile-readiness-{rank}-{category}",
+                category=category,
+                category_label=CATEGORY_LABELS[category],
+                rank=rank,
+                action=_action_for(category, result.category_statuses[category]),
+                rationale=(
+                    f"{CATEGORY_LABELS[category]} has the largest remaining weighted gap "
+                    f"at rank {rank}."
+                ),
+                recommendation_type=_recommendation_type_for(category),
+            )
+        )
+        if len(recommendations) >= limit:
+            break
+
+    return recommendations
+
+
+def _action_for(category: str, status: str) -> str:
+    if category == CATEGORY_ATS:
+        if status == "capped_unparseable":
+            return "Upload a parseable resume file and rerun ATS compliance checks."
+        return "Fix ATS blockers: parseability, required sections, contact presence, and role keywords."
+    if category == CATEGORY_FORMATTING:
+        return "Standardize section order, bullet style, page length, tense, and readability."
+    if category == CATEGORY_IMPACT:
+        if status == "withheld_unparseable":
+            return "Upload a readable resume so impact scoring can evaluate accomplishments."
+        return "Rewrite weak bullets with quantified outcomes, action verbs, scope, and role relevance."
+    if category == CATEGORY_LINKEDIN:
+        if status == "missing":
+            return "Add or skip LinkedIn feedback so the score is no longer provisional."
+        return "Align LinkedIn headline, About, experience, skills, and projects with the target role."
+    if category == CATEGORY_MENTOR_REVIEW:
+        if status == "defaulted":
+            return "Request an optional mentor/recruiter review to add human context."
+        return "Address the mentor/recruiter priority gap before the next recalculation."
+    raise ValueError(f"unknown profile readiness category: {category}")
+
+
+def _recommendation_type_for(category: str) -> str:
+    if category == CATEGORY_MENTOR_REVIEW:
+        return "human_review"
+    if category == CATEGORY_LINKEDIN:
+        return "linkedin_update"
+    if category == CATEGORY_ATS:
+        return "resume_ats_update"
+    return "resume_update"

--- a/profile_readiness/scoring.py
+++ b/profile_readiness/scoring.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import floor
+
+
+CATEGORY_ATS = "resume_ats_compliance"
+CATEGORY_FORMATTING = "resume_formatting"
+CATEGORY_IMPACT = "resume_impact"
+CATEGORY_LINKEDIN = "linkedin_profile_feedback"
+CATEGORY_MENTOR_REVIEW = "mentor_recruiter_review"
+
+CATEGORY_ORDER = (
+    CATEGORY_ATS,
+    CATEGORY_FORMATTING,
+    CATEGORY_IMPACT,
+    CATEGORY_LINKEDIN,
+    CATEGORY_MENTOR_REVIEW,
+)
+
+CATEGORY_LABELS = {
+    CATEGORY_ATS: "Resume ATS compliance",
+    CATEGORY_FORMATTING: "Resume formatting",
+    CATEGORY_IMPACT: "Resume impact",
+    CATEGORY_LINKEDIN: "LinkedIn profile feedback",
+    CATEGORY_MENTOR_REVIEW: "Mentor/recruiter review",
+}
+
+CATEGORY_WEIGHTS = {
+    CATEGORY_ATS: 0.30,
+    CATEGORY_FORMATTING: 0.15,
+    CATEGORY_IMPACT: 0.25,
+    CATEGORY_LINKEDIN: 0.20,
+    CATEGORY_MENTOR_REVIEW: 0.10,
+}
+
+CALCULATION_VERSION = "profile_readiness_v1"
+MENTOR_REVIEW_DEFAULT_SCORE = 50
+
+
+@dataclass(frozen=True)
+class ProfileReadinessInput:
+    ats_score: int | None = None
+    formatting_score: int | None = None
+    impact_score: int | None = None
+    linkedin_score: int | None = None
+    mentor_review_score: int | None = None
+    resume_uploaded: bool = True
+    resume_parseable: bool = True
+    linkedin_confirmed_missing: bool = False
+    low_confidence: bool = False
+
+
+@dataclass(frozen=True)
+class ProfileReadinessResult:
+    score: int | None
+    unrounded_score: float | None
+    readiness_band: str | None
+    category_scores: dict[str, int | None]
+    category_statuses: dict[str, str]
+    category_weights: dict[str, float]
+    weighted_gaps: dict[str, float]
+    top_gap_category: str | None
+    top_gap_label: str | None
+    lowest_scoring_category: str | None
+    provisional: bool
+    human_reviewed: bool
+    calculation_version: str = CALCULATION_VERSION
+
+
+def calculate_readiness(profile: ProfileReadinessInput) -> ProfileReadinessResult:
+    """Calculate the first-prototype profile readiness score from GURU-104 docs."""
+    if not profile.resume_uploaded:
+        return _empty_resume_result(profile)
+
+    category_scores: dict[str, int | None] = {}
+    category_statuses: dict[str, str] = {}
+
+    ats_score = _normalize_score(profile.ats_score, default=20 if not profile.resume_parseable else None)
+    if not profile.resume_parseable:
+        ats_score = min(ats_score if ats_score is not None else 20, 20)
+        category_statuses[CATEGORY_ATS] = "capped_unparseable"
+    else:
+        category_statuses[CATEGORY_ATS] = "scored" if ats_score is not None else "missing"
+    category_scores[CATEGORY_ATS] = ats_score
+
+    formatting_score = _normalize_score(profile.formatting_score)
+    category_scores[CATEGORY_FORMATTING] = formatting_score
+    category_statuses[CATEGORY_FORMATTING] = "scored" if formatting_score is not None else "missing"
+
+    if profile.resume_parseable:
+        impact_score = _normalize_score(profile.impact_score)
+        category_scores[CATEGORY_IMPACT] = impact_score
+        category_statuses[CATEGORY_IMPACT] = "scored" if impact_score is not None else "missing"
+    else:
+        category_scores[CATEGORY_IMPACT] = None
+        category_statuses[CATEGORY_IMPACT] = "withheld_unparseable"
+
+    linkedin_score = _normalize_score(profile.linkedin_score)
+    if linkedin_score is None and profile.linkedin_confirmed_missing:
+        linkedin_score = 0
+        category_statuses[CATEGORY_LINKEDIN] = "confirmed_missing"
+    else:
+        category_statuses[CATEGORY_LINKEDIN] = "scored" if linkedin_score is not None else "missing"
+    category_scores[CATEGORY_LINKEDIN] = linkedin_score
+
+    mentor_review_score = _normalize_score(profile.mentor_review_score)
+    human_reviewed = mentor_review_score is not None
+    if mentor_review_score is None:
+        mentor_review_score = MENTOR_REVIEW_DEFAULT_SCORE
+        category_statuses[CATEGORY_MENTOR_REVIEW] = "defaulted"
+    else:
+        category_statuses[CATEGORY_MENTOR_REVIEW] = "scored"
+    category_scores[CATEGORY_MENTOR_REVIEW] = mentor_review_score
+
+    weighted_gaps = _weighted_gaps(category_scores)
+    missing_weight = sum(
+        CATEGORY_WEIGHTS[category]
+        for category, score in category_scores.items()
+        if score is None
+    )
+    available_weight = 1 - missing_weight
+    weighted_total = sum(
+        (score or 0) * CATEGORY_WEIGHTS[category]
+        for category, score in category_scores.items()
+        if score is not None
+    )
+
+    unrounded_score = weighted_total / available_weight if available_weight > 0 else None
+    score = _round_score(unrounded_score) if unrounded_score is not None else None
+    readiness_band = readiness_band_for_score(score) if score is not None else None
+    top_gap_category = _top_gap_category(weighted_gaps)
+
+    provisional = profile.low_confidence or any(score is None for score in category_scores.values())
+
+    return ProfileReadinessResult(
+        score=score,
+        unrounded_score=round(unrounded_score, 4) if unrounded_score is not None else None,
+        readiness_band=readiness_band,
+        category_scores=category_scores,
+        category_statuses=category_statuses,
+        category_weights=dict(CATEGORY_WEIGHTS),
+        weighted_gaps=weighted_gaps,
+        top_gap_category=top_gap_category,
+        top_gap_label=CATEGORY_LABELS[top_gap_category] if top_gap_category else None,
+        lowest_scoring_category=_lowest_scoring_category(category_scores),
+        provisional=provisional,
+        human_reviewed=human_reviewed,
+    )
+
+
+def readiness_band_for_score(score: int) -> str:
+    if score < 0 or score > 100:
+        raise ValueError("readiness score must be between 0 and 100")
+    if score <= 39:
+        return "Not ready"
+    if score <= 64:
+        return "Needs work"
+    if score <= 79:
+        return "Approaching ready"
+    if score <= 89:
+        return "Ready"
+    return "Strong"
+
+
+def rank_categories_by_weighted_gap(result: ProfileReadinessResult) -> list[str]:
+    return sorted(
+        CATEGORY_ORDER,
+        key=lambda category: (
+            result.weighted_gaps[category],
+            CATEGORY_WEIGHTS[category],
+            -CATEGORY_ORDER.index(category),
+        ),
+        reverse=True,
+    )
+
+
+def _empty_resume_result(profile: ProfileReadinessInput) -> ProfileReadinessResult:
+    category_scores = {category: None for category in CATEGORY_ORDER}
+    category_statuses = {category: "missing" for category in CATEGORY_ORDER}
+    weighted_gaps = _weighted_gaps(category_scores)
+    top_gap_category = _top_gap_category(weighted_gaps)
+    return ProfileReadinessResult(
+        score=None,
+        unrounded_score=None,
+        readiness_band=None,
+        category_scores=category_scores,
+        category_statuses=category_statuses,
+        category_weights=dict(CATEGORY_WEIGHTS),
+        weighted_gaps=weighted_gaps,
+        top_gap_category=top_gap_category,
+        top_gap_label=CATEGORY_LABELS[top_gap_category] if top_gap_category else None,
+        lowest_scoring_category=None,
+        provisional=True,
+        human_reviewed=profile.mentor_review_score is not None,
+    )
+
+
+def _normalize_score(value: int | None, default: int | None = None) -> int | None:
+    if value is None:
+        value = default
+    if value is None:
+        return None
+    return max(0, min(100, int(value)))
+
+
+def _round_score(value: float) -> int:
+    return max(0, min(100, floor(value + 0.5)))
+
+
+def _weighted_gaps(category_scores: dict[str, int | None]) -> dict[str, float]:
+    gaps = {}
+    for category in CATEGORY_ORDER:
+        score = category_scores[category]
+        category_score = 0 if score is None else score
+        gaps[category] = round((100 - category_score) * CATEGORY_WEIGHTS[category], 2)
+    return gaps
+
+
+def _top_gap_category(weighted_gaps: dict[str, float]) -> str | None:
+    if not weighted_gaps:
+        return None
+    return max(
+        CATEGORY_ORDER,
+        key=lambda category: (
+            weighted_gaps[category],
+            CATEGORY_WEIGHTS[category],
+            -CATEGORY_ORDER.index(category),
+        ),
+    )
+
+
+def _lowest_scoring_category(category_scores: dict[str, int | None]) -> str | None:
+    scored_categories = [
+        category for category in CATEGORY_ORDER if category_scores[category] is not None
+    ]
+    if not scored_categories:
+        return None
+    return min(scored_categories, key=lambda category: category_scores[category] or 0)

--- a/tests/test_profile_readiness.py
+++ b/tests/test_profile_readiness.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from profile_readiness import (
+    ProfileReadinessInput,
+    build_recalculation_requested_event,
+    build_recommendation_completed_event,
+    build_recommendation_started_event,
+    build_recommendation_viewed_event,
+    build_recommendations_generated_event,
+    build_score_recalculated_event,
+    calculate_readiness,
+    generate_recommendations,
+    readiness_band_for_score,
+)
+from profile_readiness.scoring import (
+    CATEGORY_ATS,
+    CATEGORY_FORMATTING,
+    CATEGORY_IMPACT,
+    CATEGORY_LINKEDIN,
+    CATEGORY_MENTOR_REVIEW,
+)
+
+
+class ProfileReadinessTests(unittest.TestCase):
+    def test_weighted_score_calculation_and_top_gap(self) -> None:
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=70,
+                impact_score=60,
+                linkedin_score=50,
+                mentor_review_score=90,
+            )
+        )
+
+        self.assertEqual(result.score, 69)
+        self.assertEqual(result.unrounded_score, 68.5)
+        self.assertEqual(result.readiness_band, "Approaching ready")
+        self.assertFalse(result.provisional)
+        self.assertTrue(result.human_reviewed)
+        self.assertEqual(
+            result.category_scores,
+            {
+                CATEGORY_ATS: 80,
+                CATEGORY_FORMATTING: 70,
+                CATEGORY_IMPACT: 60,
+                CATEGORY_LINKEDIN: 50,
+                CATEGORY_MENTOR_REVIEW: 90,
+            },
+        )
+        self.assertEqual(result.weighted_gaps[CATEGORY_IMPACT], 10)
+        self.assertEqual(result.weighted_gaps[CATEGORY_LINKEDIN], 10)
+        self.assertEqual(result.top_gap_category, CATEGORY_IMPACT)
+
+    def test_readiness_bands_are_exact(self) -> None:
+        bands = {
+            0: "Not ready",
+            39: "Not ready",
+            40: "Needs work",
+            64: "Needs work",
+            65: "Approaching ready",
+            79: "Approaching ready",
+            80: "Ready",
+            89: "Ready",
+            90: "Strong",
+            100: "Strong",
+        }
+
+        for score, expected_band in bands.items():
+            with self.subTest(score=score):
+                self.assertEqual(readiness_band_for_score(score), expected_band)
+
+        with self.assertRaises(ValueError):
+            readiness_band_for_score(-1)
+        with self.assertRaises(ValueError):
+            readiness_band_for_score(101)
+
+    def test_missing_linkedin_feedback_makes_score_provisional(self) -> None:
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=80,
+                impact_score=80,
+                linkedin_score=None,
+            )
+        )
+
+        self.assertEqual(result.score, 76)
+        self.assertTrue(result.provisional)
+        self.assertFalse(result.human_reviewed)
+        self.assertIsNone(result.category_scores[CATEGORY_LINKEDIN])
+        self.assertEqual(result.weighted_gaps[CATEGORY_LINKEDIN], 20)
+        self.assertEqual(result.top_gap_category, CATEGORY_LINKEDIN)
+
+        recommendations = generate_recommendations(result)
+        self.assertEqual(recommendations[0].category, CATEGORY_LINKEDIN)
+        self.assertIn("Add or skip LinkedIn feedback", recommendations[0].action)
+
+    def test_confirmed_missing_linkedin_is_scored_as_zero(self) -> None:
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=80,
+                impact_score=80,
+                linkedin_score=None,
+                linkedin_confirmed_missing=True,
+            )
+        )
+
+        self.assertEqual(result.score, 61)
+        self.assertFalse(result.provisional)
+        self.assertEqual(result.category_scores[CATEGORY_LINKEDIN], 0)
+        self.assertEqual(result.category_statuses[CATEGORY_LINKEDIN], "confirmed_missing")
+
+    def test_human_reviewed_scoring_changes_review_state(self) -> None:
+        unreviewed = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=80,
+                impact_score=80,
+                linkedin_score=80,
+            )
+        )
+        reviewed = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=80,
+                impact_score=80,
+                linkedin_score=80,
+                mentor_review_score=90,
+            )
+        )
+
+        self.assertEqual(unreviewed.score, 77)
+        self.assertFalse(unreviewed.human_reviewed)
+        self.assertEqual(unreviewed.category_scores[CATEGORY_MENTOR_REVIEW], 50)
+        self.assertEqual(reviewed.score, 81)
+        self.assertEqual(reviewed.readiness_band, "Ready")
+        self.assertTrue(reviewed.human_reviewed)
+        self.assertEqual(reviewed.category_scores[CATEGORY_MENTOR_REVIEW], 90)
+
+    def test_weighted_gap_ranking_drives_recommendation_ordering(self) -> None:
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=90,
+                formatting_score=40,
+                impact_score=80,
+                linkedin_score=20,
+                mentor_review_score=50,
+            )
+        )
+
+        recommendations = generate_recommendations(result)
+
+        self.assertEqual(result.top_gap_category, CATEGORY_LINKEDIN)
+        self.assertEqual([item.category for item in recommendations], [CATEGORY_LINKEDIN, CATEGORY_FORMATTING, CATEGORY_IMPACT])
+        self.assertEqual([item.rank for item in recommendations], [1, 2, 3])
+
+    def test_unparseable_resume_caps_ats_and_withholds_impact(self) -> None:
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=70,
+                impact_score=80,
+                linkedin_score=70,
+                resume_parseable=False,
+            )
+        )
+
+        self.assertEqual(result.category_scores[CATEGORY_ATS], 20)
+        self.assertEqual(result.category_statuses[CATEGORY_ATS], "capped_unparseable")
+        self.assertIsNone(result.category_scores[CATEGORY_IMPACT])
+        self.assertEqual(result.category_statuses[CATEGORY_IMPACT], "withheld_unparseable")
+        self.assertTrue(result.provisional)
+
+    def test_event_payloads_are_privacy_safe(self) -> None:
+        occurred_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=90,
+                formatting_score=40,
+                impact_score=80,
+                linkedin_score=20,
+                mentor_review_score=50,
+            )
+        )
+        recommendations = generate_recommendations(result)
+
+        recalculation_requested = build_recalculation_requested_event(
+            user_id="user-1",
+            profile_id="profile-1",
+            source="manual_edit",
+            trigger_event_id="trigger-1",
+            trigger_reason="profile_inputs_updated",
+            changed_inputs=[
+                "ats_score",
+                "resume_text",
+                "email",
+                "external_profile_url",
+                "mentor_notes",
+                "target_role",
+            ],
+            event_id="event-1",
+            occurred_at=occurred_at,
+        )
+        score_recalculated = build_score_recalculated_event(
+            user_id="user-1",
+            profile_id="profile-1",
+            source="system_recalculation",
+            score_id="score-1",
+            previous_result=None,
+            new_result=result,
+            event_id="event-2",
+            occurred_at=occurred_at,
+        )
+        recommendations_generated = build_recommendations_generated_event(
+            user_id="user-1",
+            profile_id="profile-1",
+            source="system_recalculation",
+            score_id="score-1",
+            recommendations=recommendations,
+            generation_reason="score_recalculated",
+            confidence="standard",
+            event_id="event-3",
+            occurred_at=occurred_at,
+        )
+        recommendation_viewed = build_recommendation_viewed_event(
+            user_id="user-1",
+            profile_id="profile-1",
+            source="manual_edit",
+            recommendation=recommendations[0],
+            score_id="score-1",
+            event_id="event-4",
+            occurred_at=occurred_at,
+        )
+        recommendation_started = build_recommendation_started_event(
+            user_id="user-1",
+            profile_id="profile-1",
+            source="manual_edit",
+            recommendation=recommendations[0],
+            score_id="score-1",
+            action_type="linkedin_update",
+            event_id="event-5",
+            occurred_at=occurred_at,
+        )
+        recommendation_completed = build_recommendation_completed_event(
+            user_id="user-1",
+            profile_id="profile-1",
+            source="manual_edit",
+            recommendation=recommendations[0],
+            score_id="score-1",
+            completion_source="user_marked_complete",
+            recalculation_requested=True,
+            event_id="event-6",
+            occurred_at=occurred_at,
+        )
+
+        self.assertEqual(recalculation_requested["changed_inputs"], ["ats_score", "target_role"])
+        self.assertEqual(score_recalculated["category_scores"][CATEGORY_LINKEDIN], 20)
+        self.assertEqual(recommendations_generated["top_category"], CATEGORY_LINKEDIN)
+        self.assertEqual(recommendation_viewed["recommendation_id"], recommendations[0].recommendation_id)
+        self.assertEqual(recommendation_started["action_type"], "linkedin_update")
+        self.assertTrue(recommendation_completed["recalculation_requested"])
+
+        serialized_events = repr(
+            [
+                recalculation_requested,
+                score_recalculated,
+                recommendations_generated,
+                recommendation_viewed,
+                recommendation_started,
+                recommendation_completed,
+            ]
+        ).lower()
+        for forbidden in (
+            "resume_text",
+            "linkedin_text",
+            "contact_information",
+            "email",
+            "external_profile_url",
+            "mentor_notes",
+            "recruiter_notes",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, serialized_events)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_profile_readiness.py
+++ b/tests/test_profile_readiness.py
@@ -4,8 +4,11 @@ import unittest
 from datetime import datetime, timezone
 
 from profile_readiness import (
+    HISTORY_SESSION_KEY,
     ProfileReadinessInput,
+    append_history_entry,
     build_recalculation_requested_event,
+    build_history_entry,
     build_recommendation_completed_event,
     build_recommendation_started_event,
     build_recommendation_viewed_event,
@@ -13,7 +16,9 @@ from profile_readiness import (
     build_score_recalculated_event,
     calculate_readiness,
     generate_recommendations,
+    latest_score_delta,
     readiness_band_for_score,
+    recent_history_entries,
 )
 from profile_readiness.scoring import (
     CATEGORY_ATS,
@@ -175,6 +180,139 @@ class ProfileReadinessTests(unittest.TestCase):
         self.assertIsNone(result.category_scores[CATEGORY_IMPACT])
         self.assertEqual(result.category_statuses[CATEGORY_IMPACT], "withheld_unparseable")
         self.assertTrue(result.provisional)
+
+    def test_session_history_appends_and_returns_recent_entries_newest_last(self) -> None:
+        session_state = {}
+        first = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=50,
+                formatting_score=50,
+                impact_score=50,
+                linkedin_score=50,
+            )
+        )
+        second = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=70,
+                formatting_score=60,
+                impact_score=65,
+                linkedin_score=55,
+            )
+        )
+        third = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=80,
+                formatting_score=75,
+                impact_score=70,
+                linkedin_score=80,
+                mentor_review_score=90,
+            )
+        )
+
+        append_history_entry(
+            session_state,
+            first,
+            trigger_reason="initial_calculation",
+            timestamp=datetime(2026, 1, 1, 12, tzinfo=timezone.utc),
+        )
+        append_history_entry(
+            session_state,
+            second,
+            trigger_reason="resume_update",
+            timestamp=datetime(2026, 1, 2, 12, tzinfo=timezone.utc),
+        )
+        append_history_entry(
+            session_state,
+            third,
+            trigger_reason="mentor_recruiter_review_update",
+            timestamp=datetime(2026, 1, 3, 12, tzinfo=timezone.utc),
+        )
+
+        entries = recent_history_entries(session_state, limit=2)
+
+        self.assertIn(HISTORY_SESSION_KEY, session_state)
+        self.assertEqual([entry.score for entry in entries], [second.score, third.score])
+        self.assertEqual(
+            [entry.trigger_reason for entry in entries],
+            ["resume_update", "mentor_recruiter_review_update"],
+        )
+        self.assertTrue(entries[-1].human_reviewed)
+
+    def test_latest_score_delta_compares_to_previous_scored_entry(self) -> None:
+        first = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=55,
+                formatting_score=55,
+                impact_score=55,
+                linkedin_score=55,
+            )
+        )
+        unscored = calculate_readiness(ProfileReadinessInput(resume_uploaded=False))
+        latest = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=85,
+                formatting_score=75,
+                impact_score=80,
+                linkedin_score=75,
+            )
+        )
+
+        history = [
+            build_history_entry(first, trigger_reason="initial_calculation"),
+            build_history_entry(unscored, trigger_reason="resume_update"),
+            build_history_entry(latest, trigger_reason="resume_update"),
+        ]
+
+        self.assertEqual(latest_score_delta(history), latest.score - first.score)
+        self.assertIsNone(latest_score_delta(history[:1]))
+        self.assertIsNone(latest_score_delta(history[:2]))
+
+    def test_history_entries_are_privacy_safe(self) -> None:
+        session_state = {}
+        result = calculate_readiness(
+            ProfileReadinessInput(
+                ats_score=90,
+                formatting_score=40,
+                impact_score=80,
+                linkedin_score=20,
+                mentor_review_score=50,
+            )
+        )
+
+        entry = append_history_entry(
+            session_state,
+            result,
+            trigger_reason="resume_text",
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        payload = entry.as_payload()
+
+        self.assertEqual(
+            set(payload),
+            {
+                "score",
+                "readiness_band",
+                "top_gap_category",
+                "provisional",
+                "human_reviewed",
+                "trigger_reason",
+                "timestamp",
+            },
+        )
+        self.assertEqual(payload["trigger_reason"], "profile_recalculated")
+        self.assertNotIn("category_scores", payload)
+        self.assertNotIn("weighted_gaps", payload)
+
+        stored_payload = repr(session_state).lower()
+        for forbidden in (
+            "resume_text",
+            "linkedin_text",
+            "external_profile_url",
+            "mentor_notes",
+            "recruiter_notes",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, stored_payload)
 
     def test_event_payloads_are_privacy_safe(self) -> None:
         occurred_at = datetime(2026, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
Summary:
- Add a concise README reference to the profile readiness documentation pack.
- Document first-prototype scope, scoring model, tracking events, and user-facing acceptance scenarios for profile readiness.
- Capture privacy expectations and edge cases for readiness scoring metadata.

Checks:
- git diff --check -- README.md docs/profile-readiness
- find docs/profile-readiness -maxdepth 1 -type f | sort
- rg -n '(/Users/|sk-[A-Za-z0-9]|ghp_[A-Za-z0-9]|xox[baprs]-|AKIA[0-9A-Z]{16}|api[_-]?key|access[_-]?token|password)' README.md docs/profile-readiness