### PR TITLE
Add budget-capped monthly flower checkout workflow

### DIFF
--- a/personal-secretary/README.md
+++ b/personal-secretary/README.md
@@ -42,6 +42,25 @@ Bakery endpoints:
 - `POST /v1/bakery/delivery-quote`
 - `POST /v1/bakery/order`
 
+### Monthly flower subscription checkout
+
+The flower workflow checks the live public catalog and prepares a user-reviewed checkout handoff. It does not collect a raw delivery address or payment data, place an order, create a subscription, or charge payment.
+
+- Merchant: V&J Plant Shop, Vancouver
+- Product: Classic Floral Subscription
+- Variant: 3 Months
+- Cadence: Monthly (three deliveries)
+- Destination: configured `wife_home` reference only
+- Budget: CAD 80 maximum per delivery; no add-ons or upgrades
+- Current catalog price at implementation: CAD 71.99 per delivery
+
+Flower endpoints:
+
+- `POST /v1/flowers/subscription-quote`
+- `POST /v1/flowers/prepare-checkout`
+
+The prepare-checkout result is intentionally `checkout_required` with `live_order: false`. A completed checkout on the florist's site is the only valid evidence that an order and recurring subscription exist.
+
 The generic workflow endpoints are also available for registered workflows:
 
 - `POST /v1/workflows/{workflowId}/quote`
@@ -57,6 +76,8 @@ The generic workflow endpoints are also available for registered workflows:
 6. The API returns a normalized result without exposing internal tokens or secrets.
 
 For haircut booking, execution opens a fresh browser session, rechecks the exact slot, verifies the checkout, fills contact details from Render secrets, and submits only when Square still shows CAD $0 due today.
+
+For flowers, execution fetches the florist catalog again and rejects any changed availability, product, cadence, commitment, price, or budget terms before returning the official checkout handoff.
 
 ## Security
 

--- a/personal-secretary/custom-gpt-instructions.md
+++ b/personal-secretary/custom-gpt-instructions.md
@@ -30,6 +30,17 @@ The approved bakery delivery workflow is sandbox-only:
 
 Never claim that a bakery order was placed with a real merchant. Report sandbox bakery results as sandbox confirmations only.
 
+The approved flower workflow is a live-catalog checkout handoff:
+
+- V&J Plant Shop in Vancouver only
+- Classic Floral Subscription, `3 Months` variant only
+- `Monthly (3 Month)` cadence only
+- configured `wife_home` delivery reference only; never send a raw address to the action
+- CAD 80 maximum per delivery, with no tips, add-ons, upgrades, or substitutions selected by the action
+- checkout is completed on the florist website; the action itself cannot place an order, create a subscription, or charge payment
+
+Never claim flowers were ordered or a subscription was created when the action returns `checkout_required`. Treat only a completed florist checkout confirmation as an order.
+
 ## Required haircut workflow
 
 1. Call `findUsualHaircutAvailability` to obtain a live quote.
@@ -49,14 +60,24 @@ Never claim that a bakery order was placed with a real merchant. Report sandbox 
 5. Report the result as a sandbox bakery order confirmation only.
 6. If the quote expires or is rejected, request a fresh quote before executing.
 
+## Required flower workflow
+
+1. Call `getMonthlyFlowerSubscriptionQuote` using only the configured `wife_home` destination reference.
+2. Tell Harsh the exact florist, product, three-delivery commitment, monthly cadence, price per delivery, CAD 80 cap, and that florist checkout is still required.
+3. Preserve the returned `quote_token` exactly. Never display it to Harsh.
+4. Call `prepareMonthlyFlowerSubscriptionCheckout` only after Harsh approves that exact quote and the platform confirmation step permits it.
+5. If the result is `checkout_required`, provide the official checkout link and say to select `3 Months` and `Monthly`. Do not claim an order or subscription exists.
+6. Before any florist checkout is submitted, verify the wife's exact delivery address and recipient contact details, show the final recurring terms and total, and obtain action-time confirmation.
+7. If the live catalog price exceeds CAD 80, availability changes, or the quote expires, stop and request a fresh quote. Never switch to a different plan or florist automatically.
+
 ## Safety and privacy
 
 - Never ask Harsh to provide his phone number or email when the action is configured; those details are held privately by the service.
 - Never reveal API keys, quote tokens, internal IDs, Square confirmation URLs, cancellation tokens, or rescheduling tokens.
 - Never book a different business, barber, service, date rule, or paid checkout through this action.
-- Never send raw delivery addresses, payment data, contact details, browser state, or credentials to bakery endpoints.
+- Never send raw delivery addresses, payment data, contact details, browser state, or credentials to bakery or flower action endpoints.
 - Never add services or upgrades.
-- Never make more than one appointment or sandbox bakery order for the same request.
+- Never make more than one appointment, sandbox bakery order, or flower checkout handoff for the same request.
 - For cancellations or rescheduling, explain that this version supports booking only and use the confirmation email unless a dedicated action is added later.
 
 ## Communication style

--- a/personal-secretary/openapi.yaml
+++ b/personal-secretary/openapi.yaml
@@ -1,12 +1,13 @@
 openapi: 3.1.0
 info:
   title: Gurukul Personal Secretary
-  version: 1.1.0
+  version: 1.2.0
   description: >-
     Private quote-and-confirm action platform for Harsh. It preserves the Del
-    Ray Barbershop haircut workflow and adds a sandbox bakery delivery workflow.
-    Every consequential action requires an unchanged short-lived signed quote
-    token and explicit confirmation.
+    Ray Barbershop haircut workflow, a sandbox bakery delivery workflow, and a
+    budget-capped monthly floral subscription checkout handoff. Every
+    consequential action requires an unchanged short-lived signed quote token
+    and explicit confirmation.
 servers:
   - url: https://gurukul-personal-secretary-harsh.onrender.com
 paths:
@@ -161,6 +162,72 @@ paths:
           description: Invalid API key.
         '502':
           description: Sandbox bakery provider failed.
+  /v1/flowers/subscription-quote:
+    post:
+      operationId: getMonthlyFlowerSubscriptionQuote
+      summary: Quote the approved monthly floral subscription.
+      description: >-
+        Checks the V&J public catalog for the Classic Floral Subscription,
+        three-month variant, and monthly selling plan. The price must remain at
+        or below CAD 80 per delivery. No address, payment data, order, or
+        subscription is created by this operation.
+      x-openai-isConsequential: false
+      security:
+        - SecretaryApiKey: []
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlowerSubscriptionQuoteRequest'
+      responses:
+        '200':
+          description: Live florist catalog quote.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowerSubscriptionQuote'
+        '400':
+          description: Request validation failed.
+        '409':
+          description: The configured plan is unavailable or over budget.
+        '401':
+          description: Invalid API key.
+        '502':
+          description: Florist catalog lookup failed.
+  /v1/flowers/prepare-checkout:
+    post:
+      operationId: prepareMonthlyFlowerSubscriptionCheckout
+      summary: Recheck and return the approved florist checkout handoff.
+      description: >-
+        Rechecks the exact signed quote and returns the official product page
+        plus the pinned checkout selections. It does not place an order, start
+        a subscription, transmit a delivery address, or charge payment. The
+        user must review and complete checkout with the florist.
+      x-openai-isConsequential: true
+      security:
+        - SecretaryApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ConfirmQuoteRequest'
+      responses:
+        '200':
+          description: Verified checkout handoff.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlowerCheckoutResult'
+        '400':
+          description: Confirmation or quote validation failed.
+        '409':
+          description: Florist availability, price, or terms changed.
+        '401':
+          description: Invalid API key.
+        '502':
+          description: Florist catalog recheck failed.
 components:
   securitySchemes:
     SecretaryApiKey:
@@ -467,3 +534,183 @@ components:
         provider_reference:
           type: string
           const: fake_bakery
+    FlowerSubscriptionQuoteRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        delivery_destination_ref:
+          type: string
+          enum: [wife_home]
+          default: wife_home
+          description: Configured destination reference only. Never send a raw address.
+    FlowerSubscriptionQuote:
+      type: object
+      required:
+        - workflow
+        - proposal
+        - quote_token
+        - quote_expires_at
+        - requires_confirmation
+      properties:
+        workflow:
+          type: string
+          const: flower_subscription
+        proposal:
+          $ref: '#/components/schemas/FlowerSubscriptionProposal'
+        quote_token:
+          type: string
+        quote_expires_at:
+          type: string
+          format: date-time
+        requires_confirmation:
+          type: boolean
+          const: true
+    FlowerSubscriptionProposal:
+      type: object
+      required:
+        - workflow
+        - provider
+        - live_order
+        - merchant
+        - product
+        - subscription
+        - delivery_destination_ref
+        - cadence
+        - commitment_deliveries
+        - price_per_delivery_cad
+        - maximum_per_delivery_cad
+        - currency
+        - requires_checkout
+        - checkout_url
+      properties:
+        workflow:
+          type: string
+          const: flower_subscription
+        provider:
+          type: string
+          const: vj_shopify_checkout
+        live_order:
+          type: boolean
+          const: false
+        merchant:
+          $ref: '#/components/schemas/FlowerMerchant'
+        product:
+          $ref: '#/components/schemas/FlowerProduct'
+        subscription:
+          $ref: '#/components/schemas/FlowerSubscriptionTerms'
+        delivery_destination_ref:
+          type: string
+          const: wife_home
+        cadence:
+          type: string
+          const: monthly
+        commitment_deliveries:
+          type: integer
+          const: 3
+        price_per_delivery_cad:
+          type: number
+          maximum: 80
+        maximum_per_delivery_cad:
+          type: number
+          const: 80
+        currency:
+          type: string
+          const: CAD
+        requires_checkout:
+          type: boolean
+          const: true
+        checkout_url:
+          type: string
+          format: uri
+    FlowerMerchant:
+      type: object
+      required: [id, name, location]
+      properties:
+        id:
+          type: string
+          const: vj-plant-shop
+        name:
+          type: string
+          const: V&J Plant Shop
+        location:
+          type: string
+    FlowerProduct:
+      type: object
+      required: [id, title, variant_id, variant_title]
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+          const: Classic Floral Subscription
+        variant_id:
+          type: integer
+        variant_title:
+          type: string
+          const: 3 Months
+    FlowerSubscriptionTerms:
+      type: object
+      required: [selling_plan_id, name, frequency]
+      properties:
+        selling_plan_id:
+          type: integer
+        name:
+          type: string
+          const: Monthly (3 Month)
+        frequency:
+          type: string
+          const: monthly
+    FlowerCheckoutResult:
+      type: object
+      required:
+        - workflow
+        - status
+        - live_order
+        - merchant
+        - product
+        - subscription
+        - delivery_destination_ref
+        - commitment_deliveries
+        - price_per_delivery_cad
+        - maximum_per_delivery_cad
+        - currency
+        - checkout_url
+        - checkout_instructions
+      properties:
+        idempotent_replay:
+          type: boolean
+        workflow:
+          type: string
+          const: flower_subscription
+        status:
+          type: string
+          const: checkout_required
+        live_order:
+          type: boolean
+          const: false
+        merchant:
+          $ref: '#/components/schemas/FlowerMerchant'
+        product:
+          $ref: '#/components/schemas/FlowerProduct'
+        subscription:
+          $ref: '#/components/schemas/FlowerSubscriptionTerms'
+        delivery_destination_ref:
+          type: string
+          const: wife_home
+        commitment_deliveries:
+          type: integer
+          const: 3
+        price_per_delivery_cad:
+          type: number
+          maximum: 80
+        maximum_per_delivery_cad:
+          type: number
+          const: 80
+        currency:
+          type: string
+          const: CAD
+        checkout_url:
+          type: string
+          format: uri
+        checkout_instructions:
+          type: string

--- a/personal-secretary/package.json
+++ b/personal-secretary/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gurukul-personal-secretary",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Secure quote-and-confirm action API for the Gurukul Personal Secretary custom GPT.",
   "type": "commonjs",

--- a/personal-secretary/src/config.js
+++ b/personal-secretary/src/config.js
@@ -15,6 +15,28 @@ const DEFAULTS = Object.freeze({
   defaultSearchWeeks: 2,
   maxWeeks: 2,
   quoteTtlSeconds: 10 * 60,
+  flowers: {
+    merchant: {
+      id: 'vj-plant-shop',
+      name: 'V&J Plant Shop',
+      location: '1689 Johnston St #116, Vancouver, BC',
+    },
+    product: {
+      id: 8890663731456,
+      title: 'Classic Floral Subscription',
+      variantId: 46146231533824,
+      variantTitle: '3 Months',
+      sellingPlanId: 4019519744,
+      sellingPlanName: 'Monthly (3 Month)',
+      productJsonUrl: 'https://vjplantshop.com/products/classic-floral-subscription.js',
+      checkoutUrl: 'https://vjplantshop.com/products/classic-floral-subscription',
+    },
+    deliveryDestinationRefs: ['wife_home'],
+    defaultDeliveryDestinationRef: 'wife_home',
+    cadence: 'monthly',
+    commitmentDeliveries: 3,
+    spendingLimitCad: 80,
+  },
   bakery: {
     merchant: {
       id: 'sandbox-bakery',

--- a/personal-secretary/src/flowers/domain.js
+++ b/personal-secretary/src/flowers/domain.js
@@ -1,0 +1,171 @@
+const { WorkflowError } = require('../workflows/errors');
+
+const REQUEST_KEYS = new Set(['delivery_destination_ref']);
+const PROPOSAL_KEYS = new Set([
+  'cadence',
+  'commitment_deliveries',
+  'currency',
+  'delivery_destination_ref',
+  'live_order',
+  'maximum_per_delivery_cad',
+  'merchant',
+  'price_per_delivery_cad',
+  'product',
+  'provider',
+  'requires_checkout',
+  'subscription',
+  'workflow',
+  'checkout_url',
+]);
+const MERCHANT_KEYS = new Set(['id', 'location', 'name']);
+const PRODUCT_KEYS = new Set(['id', 'title', 'variant_id', 'variant_title']);
+const SUBSCRIPTION_KEYS = new Set(['frequency', 'name', 'selling_plan_id']);
+
+function fail(code, message, status = 400) {
+  throw new WorkflowError(code, message, status);
+}
+
+function assertPlainObject(value, code, message) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail(code, message);
+}
+
+function assertAllowedKeys(value, allowedKeys, code, label) {
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) fail(code, `${label} contains unsupported field: ${key}`);
+  }
+}
+
+function fromCents(value) {
+  return Number((value / 100).toFixed(2));
+}
+
+function toCents(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return Math.round(value * 100);
+}
+
+function validateFlowerRequest(input, config) {
+  assertPlainObject(input, 'invalid_request', 'Flower subscription quote request must be an object.');
+  assertAllowedKeys(input, REQUEST_KEYS, 'invalid_request', 'Flower subscription quote request');
+  const destination = input.delivery_destination_ref || config.defaultDeliveryDestinationRef;
+  if (!config.deliveryDestinationRefs.includes(destination)) {
+    fail('invalid_delivery_destination', 'Delivery destination reference is not configured.');
+  }
+  return { delivery_destination_ref: destination };
+}
+
+function findConfiguredCatalogSelection(catalog, config) {
+  if (!catalog || catalog.id !== config.product.id || catalog.title !== config.product.title || !catalog.available) {
+    fail('flower_unavailable', 'The configured floral subscription is unavailable.', 409);
+  }
+  const variant = (catalog.variants || []).find(candidate => candidate.id === config.product.variantId);
+  if (!variant || variant.title !== config.product.variantTitle || !variant.available || !variant.requires_selling_plan) {
+    fail('flower_unavailable', 'The configured three-month floral subscription is unavailable.', 409);
+  }
+  const group = (catalog.selling_plan_groups || []).find(candidate =>
+    (candidate.selling_plans || []).some(plan => plan.id === config.product.sellingPlanId));
+  const plan = group?.selling_plans?.find(candidate => candidate.id === config.product.sellingPlanId);
+  const allocation = (variant.selling_plan_allocations || []).find(candidate =>
+    candidate.selling_plan_id === config.product.sellingPlanId);
+  if (!plan || plan.name !== config.product.sellingPlanName || !plan.recurring_deliveries || !allocation) {
+    fail('flower_unavailable', 'The configured monthly selling plan is unavailable.', 409);
+  }
+  const monthlyOption = (plan.options || []).some(option => option.value === 'Every month');
+  if (!monthlyOption) fail('flower_unavailable', 'The configured selling plan is no longer monthly.', 409);
+  const priceCents = allocation.per_delivery_price ?? allocation.price;
+  if (!Number.isInteger(priceCents) || priceCents <= 0) {
+    fail('flower_quote_failed', 'The florist returned an invalid subscription price.', 502);
+  }
+  if (priceCents > toCents(config.spendingLimitCad)) {
+    fail(
+      'spending_limit_exceeded',
+      `The floral subscription exceeds the ${config.spendingLimitCad} CAD per-delivery limit.`,
+      409,
+    );
+  }
+  return { priceCents };
+}
+
+function buildFlowerProposal(request, catalog, config) {
+  const { priceCents } = findConfiguredCatalogSelection(catalog, config);
+  return {
+    workflow: 'flower_subscription',
+    provider: 'vj_shopify_checkout',
+    live_order: false,
+    merchant: { ...config.merchant },
+    product: {
+      id: config.product.id,
+      title: config.product.title,
+      variant_id: config.product.variantId,
+      variant_title: config.product.variantTitle,
+    },
+    subscription: {
+      selling_plan_id: config.product.sellingPlanId,
+      name: config.product.sellingPlanName,
+      frequency: config.cadence,
+    },
+    delivery_destination_ref: request.delivery_destination_ref,
+    cadence: config.cadence,
+    commitment_deliveries: config.commitmentDeliveries,
+    price_per_delivery_cad: fromCents(priceCents),
+    maximum_per_delivery_cad: config.spendingLimitCad,
+    currency: 'CAD',
+    requires_checkout: true,
+    checkout_url: config.product.checkoutUrl,
+  };
+}
+
+function validateFlowerProposal(proposal, config) {
+  assertPlainObject(proposal, 'quote_not_approved', 'Flower subscription proposal must be an object.');
+  assertAllowedKeys(proposal, PROPOSAL_KEYS, 'quote_not_approved', 'Flower subscription proposal');
+  assertPlainObject(proposal.merchant, 'quote_not_approved', 'Flower merchant must be an object.');
+  assertAllowedKeys(proposal.merchant, MERCHANT_KEYS, 'quote_not_approved', 'Flower merchant');
+  assertPlainObject(proposal.product, 'quote_not_approved', 'Flower product must be an object.');
+  assertAllowedKeys(proposal.product, PRODUCT_KEYS, 'quote_not_approved', 'Flower product');
+  assertPlainObject(proposal.subscription, 'quote_not_approved', 'Flower subscription must be an object.');
+  assertAllowedKeys(proposal.subscription, SUBSCRIPTION_KEYS, 'quote_not_approved', 'Flower subscription');
+
+  if (proposal.workflow !== 'flower_subscription'
+    || proposal.provider !== 'vj_shopify_checkout'
+    || proposal.live_order !== false
+    || proposal.requires_checkout !== true) {
+    fail('quote_not_approved', 'Flower subscription provider is not approved.');
+  }
+  if (proposal.currency !== 'CAD'
+    || proposal.cadence !== config.cadence
+    || proposal.commitment_deliveries !== config.commitmentDeliveries) {
+    fail('quote_not_approved', 'Flower subscription terms are not approved.');
+  }
+  for (const key of ['id', 'name', 'location']) {
+    if (proposal.merchant[key] !== config.merchant[key]) fail('quote_not_approved', 'Flower merchant is not configured.');
+  }
+  if (proposal.product.id !== config.product.id
+    || proposal.product.title !== config.product.title
+    || proposal.product.variant_id !== config.product.variantId
+    || proposal.product.variant_title !== config.product.variantTitle) {
+    fail('quote_not_approved', 'Flower product is not configured.');
+  }
+  if (proposal.subscription.selling_plan_id !== config.product.sellingPlanId
+    || proposal.subscription.name !== config.product.sellingPlanName
+    || proposal.subscription.frequency !== config.cadence) {
+    fail('quote_not_approved', 'Flower selling plan is not configured.');
+  }
+  if (!config.deliveryDestinationRefs.includes(proposal.delivery_destination_ref)) {
+    fail('quote_not_approved', 'Flower delivery destination reference is not configured.');
+  }
+  const priceCents = toCents(proposal.price_per_delivery_cad);
+  const limitCents = toCents(config.spendingLimitCad);
+  if (priceCents === null || priceCents <= 0 || priceCents > limitCents
+    || toCents(proposal.maximum_per_delivery_cad) !== limitCents) {
+    fail('spending_limit_exceeded', `Flower price must be within ${config.spendingLimitCad} CAD per delivery.`, 409);
+  }
+  if (proposal.checkout_url !== config.product.checkoutUrl) {
+    fail('quote_not_approved', 'Flower checkout URL is not approved.');
+  }
+}
+
+module.exports = {
+  buildFlowerProposal,
+  validateFlowerProposal,
+  validateFlowerRequest,
+};

--- a/personal-secretary/src/flowers/provider.js
+++ b/personal-secretary/src/flowers/provider.js
@@ -1,0 +1,63 @@
+const { isDeepStrictEqual } = require('node:util');
+const { WorkflowError } = require('../workflows/errors');
+const { buildFlowerProposal } = require('./domain');
+
+class VjFlowerSubscriptionProvider {
+  constructor({ fetchImpl = globalThis.fetch, timeoutMs = 12_000 } = {}) {
+    if (typeof fetchImpl !== 'function') throw new Error('Flower provider requires fetch');
+    this.fetchImpl = fetchImpl;
+    this.timeoutMs = timeoutMs;
+  }
+
+  async loadCatalog(config) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+    timeout.unref?.();
+    try {
+      const response = await this.fetchImpl(config.product.productJsonUrl, {
+        headers: { accept: 'application/json' },
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error(`Florist catalog returned HTTP ${response.status}`);
+      return await response.json();
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async createProposal(request, config) {
+    return buildFlowerProposal(request, await this.loadCatalog(config), config);
+  }
+
+  async prepareCheckout(proposal, config) {
+    const refreshed = buildFlowerProposal(
+      { delivery_destination_ref: proposal.delivery_destination_ref },
+      await this.loadCatalog(config),
+      config,
+    );
+    if (!isDeepStrictEqual(refreshed, proposal)) {
+      throw new WorkflowError(
+        'quote_changed',
+        'The florist availability, price, or subscription terms changed. Request a fresh quote.',
+        409,
+      );
+    }
+    return {
+      workflow: 'flower_subscription',
+      status: 'checkout_required',
+      live_order: false,
+      merchant: proposal.merchant,
+      product: proposal.product,
+      subscription: proposal.subscription,
+      delivery_destination_ref: proposal.delivery_destination_ref,
+      commitment_deliveries: proposal.commitment_deliveries,
+      price_per_delivery_cad: proposal.price_per_delivery_cad,
+      maximum_per_delivery_cad: proposal.maximum_per_delivery_cad,
+      currency: proposal.currency,
+      checkout_url: proposal.checkout_url,
+      checkout_instructions: 'Select 3 Months and Monthly, then verify the final total and delivery details before paying.',
+    };
+  }
+}
+
+module.exports = { VjFlowerSubscriptionProvider };

--- a/personal-secretary/src/flowers/workflow.js
+++ b/personal-secretary/src/flowers/workflow.js
@@ -1,0 +1,54 @@
+const { WorkflowError } = require('../workflows/errors');
+const { validateFlowerProposal, validateFlowerRequest } = require('./domain');
+
+function createFlowerSubscriptionWorkflow({ config, provider }) {
+  return {
+    id: 'flower_subscription',
+    quoteFailedCode: 'flower_quote_failed',
+    executionFailedCode: 'flower_checkout_failed',
+
+    async createProposal(input) {
+      const request = validateFlowerRequest(input, config);
+      const proposal = await provider.createProposal(request, config);
+      validateFlowerProposal(proposal, config);
+      return proposal;
+    },
+
+    validateProposal(proposal) {
+      validateFlowerProposal(proposal, config);
+    },
+
+    formatQuoteResponse({ proposal, quoteToken, quoteExpiresAt }) {
+      return {
+        workflow: 'flower_subscription',
+        proposal,
+        quote_token: quoteToken,
+        quote_expires_at: quoteExpiresAt,
+        requires_confirmation: true,
+      };
+    },
+
+    async execute(proposal) {
+      return provider.prepareCheckout(proposal, config);
+    },
+
+    auditProposal(proposal) {
+      return {
+        merchant: proposal.merchant,
+        product: proposal.product,
+        subscription: proposal.subscription,
+        delivery_destination_ref: proposal.delivery_destination_ref,
+        commitment_deliveries: proposal.commitment_deliveries,
+        price_per_delivery_cad: proposal.price_per_delivery_cad,
+        currency: proposal.currency,
+      };
+    },
+
+    mapExecutionError(error) {
+      if (error instanceof WorkflowError) return error;
+      return new WorkflowError('flower_checkout_failed', error.message, 502);
+    },
+  };
+}
+
+module.exports = { createFlowerSubscriptionWorkflow };

--- a/personal-secretary/src/server.js
+++ b/personal-secretary/src/server.js
@@ -8,6 +8,8 @@ const { WorkflowEngine, WorkflowError, tokenFingerprint } = require('./workflows
 const { createHaircutWorkflow } = require('./workflows/haircut');
 const { FakeBakeryProvider } = require('./bakery/fake-provider');
 const { createBakeryWorkflow } = require('./bakery/workflow');
+const { VjFlowerSubscriptionProvider } = require('./flowers/provider');
+const { createFlowerSubscriptionWorkflow } = require('./flowers/workflow');
 
 function createWorkflowEngine(config, audit = new ConsoleAuditLogger()) {
   return new WorkflowEngine({
@@ -16,6 +18,10 @@ function createWorkflowEngine(config, audit = new ConsoleAuditLogger()) {
       createBakeryWorkflow({
         config: config.bakery,
         provider: new FakeBakeryProvider(),
+      }),
+      createFlowerSubscriptionWorkflow({
+        config: config.flowers,
+        provider: new VjFlowerSubscriptionProvider(),
       }),
     ],
     signingKey: config.signingKey,
@@ -106,7 +112,7 @@ function createApp(options = {}) {
       status: 'ok',
       configured: Boolean(config),
       service: 'gurukul-personal-secretary',
-      workflows: config ? ['haircut', 'bakery_delivery'] : [],
+      workflows: config ? ['haircut', 'bakery_delivery', 'flower_subscription'] : [],
     });
   });
 
@@ -116,9 +122,10 @@ function createApp(options = {}) {
       '',
       'This private service uses contact details stored as deployment secrets only to complete user-requested appointments.',
       'Contact details are not returned by the API, written to the repository, or included in application logs.',
-      'The service supports approved quote-and-confirm workflows for the Del Ray Barbershop haircut and sandbox bakery delivery.',
+      'The service supports approved quote-and-confirm workflows for the Del Ray Barbershop haircut, sandbox bakery delivery, and V&J monthly floral subscription checkout.',
       'Appointment confirmations are returned without Square cancellation or rescheduling tokens.',
       'Bakery delivery uses a deterministic fake provider in this version and cannot place a real order or charge payment.',
+      'The flower workflow checks the florist public catalog and returns a checkout handoff. It does not collect addresses, payment data, place an order, or create a subscription.',
     ].join('\n'));
   });
 
@@ -172,6 +179,25 @@ function createApp(options = {}) {
       }));
     } catch (error) {
       return sendWorkflowError(res, error, 'bakery_order_failed');
+    }
+  });
+
+  app.post('/v1/flowers/subscription-quote', requireConfigured, authenticate, async (req, res) => {
+    try {
+      res.json(await engine.createQuote('flower_subscription', req.body || {}));
+    } catch (error) {
+      return sendWorkflowError(res, error, 'flower_quote_failed');
+    }
+  });
+
+  app.post('/v1/flowers/prepare-checkout', requireConfigured, authenticate, async (req, res) => {
+    try {
+      res.json(await engine.execute('flower_subscription', {
+        quote_token: req.body?.quote_token,
+        confirm: req.body?.confirm,
+      }));
+    } catch (error) {
+      return sendWorkflowError(res, error, 'flower_checkout_failed');
     }
   });
 

--- a/personal-secretary/test/flowers.test.js
+++ b/personal-secretary/test/flowers.test.js
@@ -1,0 +1,122 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { DEFAULTS } = require('../src/config');
+const { VjFlowerSubscriptionProvider } = require('../src/flowers/provider');
+const { createFlowerSubscriptionWorkflow } = require('../src/flowers/workflow');
+const { WorkflowEngine } = require('../src/workflows/engine');
+
+function catalog(overrides = {}) {
+  const price = overrides.price ?? 7199;
+  return {
+    id: 8890663731456,
+    title: 'Classic Floral Subscription',
+    available: overrides.available ?? true,
+    variants: [{
+      id: 46146231533824,
+      title: '3 Months',
+      available: overrides.variantAvailable ?? true,
+      requires_selling_plan: true,
+      selling_plan_allocations: [{
+        selling_plan_id: 4019519744,
+        price,
+        per_delivery_price: price,
+      }],
+    }],
+    selling_plan_groups: [{
+      selling_plans: [{
+        id: 4019519744,
+        name: 'Monthly (3 Month)',
+        recurring_deliveries: true,
+        options: [{ value: 'Every month' }],
+      }],
+    }],
+  };
+}
+
+function response(body) {
+  return { ok: true, status: 200, async json() { return body; } };
+}
+
+function createEngine(fetchImpl) {
+  const provider = new VjFlowerSubscriptionProvider({ fetchImpl });
+  return new WorkflowEngine({
+    workflows: [createFlowerSubscriptionWorkflow({ config: DEFAULTS.flowers, provider })],
+    signingKey: 'secret',
+    quoteTtlSeconds: 10,
+    nowSeconds: () => 100,
+    idFactory: () => 'quote-id',
+  });
+}
+
+test('flower workflow quotes the approved monthly plan under the budget cap', async () => {
+  const engine = createEngine(async () => response(catalog()));
+  const quote = await engine.createQuote('flower_subscription', {});
+
+  assert.equal(quote.workflow, 'flower_subscription');
+  assert.equal(quote.requires_confirmation, true);
+  assert.equal(quote.proposal.merchant.name, 'V&J Plant Shop');
+  assert.equal(quote.proposal.product.variant_title, '3 Months');
+  assert.equal(quote.proposal.subscription.name, 'Monthly (3 Month)');
+  assert.equal(quote.proposal.delivery_destination_ref, 'wife_home');
+  assert.equal(quote.proposal.price_per_delivery_cad, 71.99);
+  assert.equal(quote.proposal.maximum_per_delivery_cad, 80);
+  assert.equal(quote.proposal.live_order, false);
+});
+
+test('flower execution rechecks the catalog and returns checkout_required without placing an order', async () => {
+  let fetches = 0;
+  const engine = createEngine(async () => {
+    fetches += 1;
+    return response(catalog());
+  });
+  const quote = await engine.createQuote('flower_subscription', {});
+  const result = await engine.execute('flower_subscription', {
+    quote_token: quote.quote_token,
+    confirm: true,
+  });
+
+  assert.equal(fetches, 2);
+  assert.equal(result.status, 'checkout_required');
+  assert.equal(result.live_order, false);
+  assert.equal(result.price_per_delivery_cad, 71.99);
+  assert.match(result.checkout_url, /^https:\/\/vjplantshop\.com\//);
+  assert.equal('order_id' in result, false);
+});
+
+test('flower workflow rejects raw fields, unknown destinations, over-budget prices, and unavailable plans', async () => {
+  const engine = createEngine(async () => response(catalog()));
+  await assert.rejects(
+    () => engine.createQuote('flower_subscription', { address: 'raw-address' }),
+    error => error.code === 'invalid_request',
+  );
+  await assert.rejects(
+    () => engine.createQuote('flower_subscription', { delivery_destination_ref: 'office' }),
+    error => error.code === 'invalid_delivery_destination',
+  );
+
+  const expensive = createEngine(async () => response(catalog({ price: 8100 })));
+  await assert.rejects(
+    () => expensive.createQuote('flower_subscription', {}),
+    error => error.code === 'spending_limit_exceeded',
+  );
+
+  const unavailable = createEngine(async () => response(catalog({ variantAvailable: false })));
+  await assert.rejects(
+    () => unavailable.createQuote('flower_subscription', {}),
+    error => error.code === 'flower_unavailable',
+  );
+});
+
+test('flower execution rejects a changed price and does not reuse the stale quote', async () => {
+  let fetches = 0;
+  const engine = createEngine(async () => {
+    fetches += 1;
+    return response(catalog({ price: fetches === 1 ? 7199 : 7499 }));
+  });
+  const quote = await engine.createQuote('flower_subscription', {});
+
+  await assert.rejects(
+    () => engine.execute('flower_subscription', { quote_token: quote.quote_token, confirm: true }),
+    error => error.code === 'quote_changed',
+  );
+});

--- a/personal-secretary/test/server.test.js
+++ b/personal-secretary/test/server.test.js
@@ -11,7 +11,7 @@ function routePaths(app) {
     }));
 }
 
-test('server registers preserved haircut, bakery, and generic workflow routes', () => {
+test('server registers preserved haircut, bakery, flower, and generic workflow routes', () => {
   const { app } = createApp({
     config: { apiKey: 'test-key', port: 0 },
     engine: {},
@@ -25,6 +25,8 @@ test('server registers preserved haircut, bakery, and generic workflow routes', 
     { path: '/v1/book', methods: ['post'] },
     { path: '/v1/bakery/delivery-quote', methods: ['post'] },
     { path: '/v1/bakery/order', methods: ['post'] },
+    { path: '/v1/flowers/subscription-quote', methods: ['post'] },
+    { path: '/v1/flowers/prepare-checkout', methods: ['post'] },
     { path: '/v1/workflows/:workflowId/quote', methods: ['post'] },
     { path: '/v1/workflows/:workflowId/execute', methods: ['post'] },
   ]);


### PR DESCRIPTION
## Summary

- add a `flower_subscription` quote-and-confirm workflow for V&J Plant Shop
- pin the Classic Floral Subscription, 3-month variant, and monthly cadence
- enforce a hard CAD 80 per-delivery cap (current live catalog price: CAD 71.99)
- recheck availability, price, and terms before returning the official checkout handoff
- update the OpenAPI action contract, Gurukul OS instructions, privacy text, and documentation

## Safety

- returns `checkout_required` and `live_order: false`; it does not place an order or create a subscription
- accepts only the configured `wife_home` reference, never a raw address
- does not collect or transmit recipient contact details or payment data
- adds no tips, add-ons, or upgrades
- rejects changed or over-budget quotes

## Validation

- `npm run lint`
- `npm test` (18 passing)
- Redocly OpenAPI validation (valid; two existing-style advisory warnings)
- live V&J catalog quote and recheck at CAD 71.99

## Deployment

PR only. Merge, Render deployment, live Gurukul OS GPT update, and florist checkout are intentionally not performed.