### PR TITLE
Fix flower checkout quote handoff

### DIFF
--- a/personal-secretary/src/flowers/domain.js
+++ b/personal-secretary/src/flowers/domain.js
@@ -86,8 +86,7 @@ function findConfiguredCatalogSelection(catalog, config) {
   return { priceCents };
 }
 
-function buildFlowerProposal(request, catalog, config) {
-  const { priceCents } = findConfiguredCatalogSelection(catalog, config);
+function createConfiguredFlowerProposal(request, pricePerDeliveryCad, config) {
   return {
     workflow: 'flower_subscription',
     provider: 'vj_shopify_checkout',
@@ -107,12 +106,17 @@ function buildFlowerProposal(request, catalog, config) {
     delivery_destination_ref: request.delivery_destination_ref,
     cadence: config.cadence,
     commitment_deliveries: config.commitmentDeliveries,
-    price_per_delivery_cad: fromCents(priceCents),
+    price_per_delivery_cad: pricePerDeliveryCad,
     maximum_per_delivery_cad: config.spendingLimitCad,
     currency: 'CAD',
     requires_checkout: true,
     checkout_url: config.product.checkoutUrl,
   };
+}
+
+function buildFlowerProposal(request, catalog, config) {
+  const { priceCents } = findConfiguredCatalogSelection(catalog, config);
+  return createConfiguredFlowerProposal(request, fromCents(priceCents), config);
 }
 
 function validateFlowerProposal(proposal, config) {
@@ -166,6 +170,7 @@ function validateFlowerProposal(proposal, config) {
 
 module.exports = {
   buildFlowerProposal,
+  createConfiguredFlowerProposal,
   validateFlowerProposal,
   validateFlowerRequest,
 };

--- a/personal-secretary/src/flowers/workflow.js
+++ b/personal-secretary/src/flowers/workflow.js
@@ -1,5 +1,9 @@
 const { WorkflowError } = require('../workflows/errors');
-const { validateFlowerProposal, validateFlowerRequest } = require('./domain');
+const {
+  createConfiguredFlowerProposal,
+  validateFlowerProposal,
+  validateFlowerRequest,
+} = require('./domain');
 
 function createFlowerSubscriptionWorkflow({ config, provider }) {
   return {
@@ -16,6 +20,22 @@ function createFlowerSubscriptionWorkflow({ config, provider }) {
 
     validateProposal(proposal) {
       validateFlowerProposal(proposal, config);
+    },
+
+    toQuotePayload(basePayload, proposal) {
+      return {
+        ...basePayload,
+        flower_quote: {
+          delivery_destination_ref: proposal.delivery_destination_ref,
+          price_per_delivery_cad: proposal.price_per_delivery_cad,
+        },
+      };
+    },
+
+    fromQuotePayload(payload) {
+      return createConfiguredFlowerProposal({
+        delivery_destination_ref: payload.flower_quote?.delivery_destination_ref,
+      }, payload.flower_quote?.price_per_delivery_cad, config);
     },
 
     formatQuoteResponse({ proposal, quoteToken, quoteExpiresAt }) {

--- a/personal-secretary/test/flowers.test.js
+++ b/personal-secretary/test/flowers.test.js
@@ -61,6 +61,7 @@ test('flower workflow quotes the approved monthly plan under the budget cap', as
   assert.equal(quote.proposal.price_per_delivery_cad, 71.99);
   assert.equal(quote.proposal.maximum_per_delivery_cad, 80);
   assert.equal(quote.proposal.live_order, false);
+  assert.ok(quote.quote_token.length < 700, `Expected compact quote token, got ${quote.quote_token.length} chars`);
 });
 
 test('flower execution rechecks the catalog and returns checkout_required without placing an order', async () => {


### PR DESCRIPTION
## Summary

- sign only the mutable flower quote fields (destination reference and live price)
- reconstruct and revalidate the pinned merchant, product, three-month term, monthly cadence, and CAD 80 cap during execution
- reduce the Action quote token below 700 characters so Gurukul OS can preserve it exactly between calls

## Why

The first production execution quoted CAD 71.99 correctly, but the full-proposal token was copied with a changed signature and `prepareMonthlyFlowerSubscriptionCheckout` returned `invalid_quote` / `Invalid quote signature`.

## Validation

- `npm run lint`
- `npm test` (18 passing)
- added an explicit compact-token length assertion

No purchase or subscription behavior is added.